### PR TITLE
Updated and new label properties on admin1 and admin2

### DIFF
--- a/data/110/872/053/3/1108720533.geojson
+++ b/data/110/872/053/3/1108720533.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.350749,
     "geom:longitude":42.288551,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0628\u0647\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720533,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Abha",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/053/3/1108720533.geojson
+++ b/data/110/872/053/3/1108720533.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.350749,
     "geom:longitude":42.288551,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0628\u0647\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Abha",
     "meso:name_loc":"\u0627\u0628\u0647\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0628\u0647\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.004394,
     "mps:longitude":42.541726,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720533,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Abha",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/053/5/1108720535.geojson
+++ b/data/110/872/053/5/1108720535.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.966495,
     "geom:longitude":42.828081,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0628\u0648 \u0639\u0631\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Abu Arish",
     "meso:name_loc":"\u0627\u0628\u0648 \u0639\u0631\u064a\u0634",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0628\u0648 \u0639\u0631\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.953796,
     "mps:longitude":42.861255,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720535,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Abu Arish",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/053/5/1108720535.geojson
+++ b/data/110/872/053/5/1108720535.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.966495,
     "geom:longitude":42.828081,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0628\u0648 \u0639\u0631\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720535,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Abu Arish",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/053/7/1108720537.geojson
+++ b/data/110/872/053/7/1108720537.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.418739,
     "geom:longitude":43.149703,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062f\u0627\u0626\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Addair",
     "meso:name_loc":"\u0627\u0644\u062f\u0627\u0626\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062f\u0627\u0626\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.423433,
     "mps:longitude":43.152345,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720537,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ad-Dair",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/053/7/1108720537.geojson
+++ b/data/110/872/053/7/1108720537.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.418739,
     "geom:longitude":43.149703,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062f\u0627\u0626\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720537,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ad-Dair",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/054/1/1108720541.geojson
+++ b/data/110/872/054/1/1108720541.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.423097,
     "geom:longitude":49.873994,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062f\u0645\u0627\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1108720541,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ad-Dammam",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/054/1/1108720541.geojson
+++ b/data/110/872/054/1/1108720541.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.423097,
     "geom:longitude":49.873994,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062f\u0645\u0627\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Addammam",
     "meso:name_loc":"\u0627\u0644\u062f\u0645\u0627\u0645",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062f\u0645\u0627\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.367715,
     "mps:longitude":49.905452,
     "mz:hierarchy_label":1,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108720541,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ad-Dammam",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/054/3/1108720543.geojson
+++ b/data/110/872/054/3/1108720543.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.8788,
     "geom:longitude":46.372896,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062f\u0631\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Addiriyah",
     "meso:name_loc":"\u0627\u0644\u062f\u0631\u0639\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062f\u0631\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.857107,
     "mps:longitude":46.350552,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720543,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ad-Diriyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/3/1108720543.geojson
+++ b/data/110/872/054/3/1108720543.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.8788,
     "geom:longitude":46.372896,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062f\u0631\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720543,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ad-Diriyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/5/1108720545.geojson
+++ b/data/110/872/054/5/1108720545.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.64339,
     "geom:longitude":44.157791,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062f\u0648\u0627\u062f\u0645\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Adduwadimi",
     "meso:name_loc":"\u0627\u0644\u062f\u0648\u0627\u062f\u0645\u064a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062f\u0648\u0627\u062f\u0645\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.648981,
     "mps:longitude":44.177733,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720545,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ad-Duwadimi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/5/1108720545.geojson
+++ b/data/110/872/054/5/1108720545.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.64339,
     "geom:longitude":44.157791,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062f\u0648\u0627\u062f\u0645\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720545,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ad-Duwadimi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/7/1108720547.geojson
+++ b/data/110/872/054/7/1108720547.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.700691,
     "geom:longitude":42.830264,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0639\u0641\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Afif",
     "meso:name_loc":"\u0639\u0641\u064a\u0641",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0639\u0641\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.834378,
     "mps:longitude":42.815029,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720547,
-    "wof:lastmodified":1555220433,
+    "wof:lastmodified":1560445030,
     "wof:name":"Afif",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/7/1108720547.geojson
+++ b/data/110/872/054/7/1108720547.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.700691,
     "geom:longitude":42.830264,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0639\u0641\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720547,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Afif",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/9/1108720549.geojson
+++ b/data/110/872/054/9/1108720549.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.75787,
     "geom:longitude":42.852127,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u062d\u062f \u0627\u0644\u0645\u0633\u0627\u0631\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720549,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ahad al-Musarihah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/054/9/1108720549.geojson
+++ b/data/110/872/054/9/1108720549.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.75787,
     "geom:longitude":42.852127,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u062d\u062f \u0627\u0644\u0645\u0633\u0627\u0631\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Ahad almusarihah",
     "meso:name_loc":"\u0627\u062d\u062f \u0627\u0644\u0645\u0633\u0627\u0631\u062d\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u062d\u062f \u0627\u0644\u0645\u0633\u0627\u0631\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.742916,
     "mps:longitude":42.86607,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720549,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ahad al-Musarihah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/055/1/1108720551.geojson
+++ b/data/110/872/055/1/1108720551.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.37064,
     "geom:longitude":43.24937,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u062d\u062f \u0631\u0641\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Ahad Rifaydah",
     "meso:name_loc":"\u0627\u062d\u062f \u0631\u0641\u064a\u062f\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u062d\u062f \u0631\u0641\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.530073,
     "mps:longitude":43.351625,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720551,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445030,
     "wof:name":"Ahd Rifaydah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/055/1/1108720551.geojson
+++ b/data/110/872/055/1/1108720551.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.37064,
     "geom:longitude":43.24937,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u062d\u062f \u0631\u0641\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720551,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Ahd Rifaydah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/055/3/1108720553.geojson
+++ b/data/110/872/055/3/1108720553.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.085392,
     "geom:longitude":46.850654,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0623\u0641\u0644\u0627\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720553,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Al-Aflaj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/055/3/1108720553.geojson
+++ b/data/110/872/055/3/1108720553.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.085392,
     "geom:longitude":46.850654,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0623\u0641\u0644\u0627\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alaflaj",
     "meso:name_loc":"\u0627\u0644\u0623\u0641\u0644\u0627\u062c",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0623\u0641\u0644\u0627\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.980883,
     "mps:longitude":46.850515,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720553,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445030,
     "wof:name":"Al-Aflaj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/055/5/1108720555.geojson
+++ b/data/110/872/055/5/1108720555.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.079082,
     "geom:longitude":50.943091,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0627\u062d\u0633\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alahsa",
     "meso:name_loc":"\u0627\u0644\u0627\u062d\u0633\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0627\u062d\u0633\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.713609,
     "mps:longitude":50.544082,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720555,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445031,
     "wof:name":"Al-Ahsa",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/055/5/1108720555.geojson
+++ b/data/110/872/055/5/1108720555.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.079082,
     "geom:longitude":50.943091,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0627\u062d\u0633\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720555,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Al-Ahsa",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/055/9/1108720559.geojson
+++ b/data/110/872/055/9/1108720559.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.423782,
     "geom:longitude":41.692894,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0639\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720559,
-    "wof:lastmodified":1560445030,
+    "wof:lastmodified":1560448399,
     "wof:name":"Al-Aqiq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/055/9/1108720559.geojson
+++ b/data/110/872/055/9/1108720559.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.423782,
     "geom:longitude":41.692894,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0639\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alaqiq",
     "meso:name_loc":"\u0627\u0644\u0639\u0642\u064a\u0642",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0639\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.425248,
     "mps:longitude":41.638181,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720559,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445030,
     "wof:name":"Al-Aqiq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/056/1/1108720561.geojson
+++ b/data/110/872/056/1/1108720561.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.036578,
     "geom:longitude":43.083152,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0639\u0627\u0631\u0636\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720561,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Al-Aridah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/056/1/1108720561.geojson
+++ b/data/110/872/056/1/1108720561.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.036578,
     "geom:longitude":43.083152,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0639\u0627\u0631\u0636\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alaridah",
     "meso:name_loc":"\u0627\u0644\u0639\u0627\u0631\u0636\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0639\u0627\u0631\u0636\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.030807,
     "mps:longitude":43.080985,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720561,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445036,
     "wof:name":"Al-Aridah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/056/3/1108720563.geojson
+++ b/data/110/872/056/3/1108720563.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.945356,
     "geom:longitude":44.165485,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0627\u0633\u064a\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720563,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Al-Asyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/3/1108720563.geojson
+++ b/data/110/872/056/3/1108720563.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.945356,
     "geom:longitude":44.165485,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0627\u0633\u064a\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alasyah",
     "meso:name_loc":"\u0627\u0644\u0627\u0633\u064a\u0627\u062d",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0627\u0633\u064a\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.883475,
     "mps:longitude":44.173512,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720563,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445036,
     "wof:name":"Al-Asyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/5/1108720565.geojson
+++ b/data/110/872/056/5/1108720565.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.792338,
     "geom:longitude":43.777556,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0628\u062f\u0627\u0626\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720565,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Al-Badai",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/5/1108720565.geojson
+++ b/data/110/872/056/5/1108720565.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.792338,
     "geom:longitude":43.777556,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0628\u062f\u0627\u0626\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Albadai",
     "meso:name_loc":"\u0627\u0644\u0628\u062f\u0627\u0626\u0639",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0628\u062f\u0627\u0626\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.850748,
     "mps:longitude":43.753852,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720565,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445036,
     "wof:name":"Al-Badai",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/7/1108720567.geojson
+++ b/data/110/872/056/7/1108720567.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.028252,
     "geom:longitude":41.466081,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0628\u0627\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Albaha",
     "meso:name_loc":"\u0627\u0644\u0628\u0627\u062d\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0628\u0627\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.038738,
     "mps:longitude":41.473174,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720567,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445036,
     "wof:name":"Al-Bahah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/056/7/1108720567.geojson
+++ b/data/110/872/056/7/1108720567.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.028252,
     "geom:longitude":41.466081,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0628\u0627\u062d\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720567,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Al-Bahah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/056/9/1108720569.geojson
+++ b/data/110/872/056/9/1108720569.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.454127,
     "geom:longitude":43.197591,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0628\u0643\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Albukayriyah",
     "meso:name_loc":"\u0627\u0644\u0628\u0643\u064a\u0631\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0628\u0643\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.436084,
     "mps:longitude":43.206451,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720569,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445036,
     "wof:name":"Al-Bukayriyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/9/1108720569.geojson
+++ b/data/110/872/056/9/1108720569.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.454127,
     "geom:longitude":43.197591,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0628\u0643\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720569,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Al-Bukayriyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/057/1/1108720571.geojson
+++ b/data/110/872/057/1/1108720571.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.985722,
     "geom:longitude":44.887238,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u063a\u0627\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720571,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Al-Ghat",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/1/1108720571.geojson
+++ b/data/110/872/057/1/1108720571.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.985722,
     "geom:longitude":44.887238,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u063a\u0627\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alghat",
     "meso:name_loc":"\u0627\u0644\u063a\u0627\u0637",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u063a\u0627\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.001493,
     "mps:longitude":44.882939,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720571,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Ghat",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/3/1108720573.geojson
+++ b/data/110/872/057/3/1108720573.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.18372,
     "geom:longitude":40.937838,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u063a\u0632\u0627\u0644\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alghazalah",
     "meso:name_loc":"\u0627\u0644\u063a\u0632\u0627\u0644\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u063a\u0632\u0627\u0644\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.159576,
     "mps:longitude":41.009111,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720573,
-    "wof:lastmodified":1555220434,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Ghazalah",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/057/3/1108720573.geojson
+++ b/data/110/872/057/3/1108720573.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.18372,
     "geom:longitude":40.937838,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u063a\u0632\u0627\u0644\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720573,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Al-Ghazalah",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/057/7/1108720577.geojson
+++ b/data/110/872/057/7/1108720577.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.458126,
     "geom:longitude":46.180675,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062d\u0631\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720577,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Al-Hariq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/7/1108720577.geojson
+++ b/data/110/872/057/7/1108720577.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.458126,
     "geom:longitude":46.180675,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062d\u0631\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alhariq",
     "meso:name_loc":"\u0627\u0644\u062d\u0631\u064a\u0642",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062d\u0631\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.627486,
     "mps:longitude":46.332588,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720577,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Hariq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/9/1108720579.geojson
+++ b/data/110/872/057/9/1108720579.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.792259,
     "geom:longitude":43.14997,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062d\u0631\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alharth",
     "meso:name_loc":"\u0627\u0644\u062d\u0631\u062b",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062d\u0631\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.814217,
     "mps:longitude":43.120227,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720579,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Harth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/057/9/1108720579.geojson
+++ b/data/110/872/057/9/1108720579.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.792259,
     "geom:longitude":43.14997,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062d\u0631\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720579,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Al-Harth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/058/1/1108720581.geojson
+++ b/data/110/872/058/1/1108720581.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.724926,
     "geom:longitude":40.976379,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062d\u0646\u0627\u0643\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alhinakiyah",
     "meso:name_loc":"\u0627\u0644\u062d\u0646\u0627\u0643\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062d\u0646\u0627\u0643\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.844582,
     "mps:longitude":41.088535,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720581,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445037,
     "wof:name":"Al-Hinakiyah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/058/1/1108720581.geojson
+++ b/data/110/872/058/1/1108720581.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.724926,
     "geom:longitude":40.976379,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062d\u0646\u0627\u0643\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720581,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Hinakiyah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/058/3/1108720583.geojson
+++ b/data/110/872/058/3/1108720583.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.378103,
     "geom:longitude":42.941155,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0639\u064a\u062f\u0627\u0628\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alidabi",
     "meso:name_loc":"\u0627\u0644\u0639\u064a\u062f\u0627\u0628\u064a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0639\u064a\u062f\u0627\u0628\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.384363,
     "mps:longitude":42.968415,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720583,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Idabi",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/058/3/1108720583.geojson
+++ b/data/110/872/058/3/1108720583.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.378103,
     "geom:longitude":42.941155,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0639\u064a\u062f\u0627\u0628\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720583,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Idabi",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/058/5/1108720585.geojson
+++ b/data/110/872/058/5/1108720585.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.923662,
     "geom:longitude":49.340545,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062c\u0628\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Aljubayl",
     "meso:name_loc":"\u0627\u0644\u062c\u0628\u064a\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062c\u0628\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.824973,
     "mps:longitude":49.335956,
     "mz:hierarchy_label":1,
@@ -89,7 +89,7 @@
         }
     ],
     "wof:id":1108720585,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Jubayl",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/058/5/1108720585.geojson
+++ b/data/110/872/058/5/1108720585.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.923662,
     "geom:longitude":49.340545,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062c\u0628\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":1108720585,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Jubayl",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/058/7/1108720587.geojson
+++ b/data/110/872/058/7/1108720587.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.909313,
     "geom:longitude":39.913104,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062c\u0645\u0648\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Aljumum",
     "meso:name_loc":"\u0627\u0644\u062c\u0645\u0648\u0645",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062c\u0645\u0648\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.992402,
     "mps:longitude":40.13547,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720587,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445037,
     "wof:name":"Al-Jumum",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/058/7/1108720587.geojson
+++ b/data/110/872/058/7/1108720587.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.909313,
     "geom:longitude":39.913104,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062c\u0645\u0648\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720587,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Jumum",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/058/9/1108720589.geojson
+++ b/data/110/872/058/9/1108720589.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.418842,
     "geom:longitude":39.916647,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0643\u0627\u0645\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkamil",
     "meso:name_loc":"\u0627\u0644\u0643\u0627\u0645\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0643\u0627\u0645\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":22.391215,
     "mps:longitude":39.911189,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720589,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445037,
     "wof:name":"Al-Kamil",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/058/9/1108720589.geojson
+++ b/data/110/872/058/9/1108720589.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.418842,
     "geom:longitude":39.916647,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0643\u0627\u0645\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720589,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Kamil",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/059/1/1108720591.geojson
+++ b/data/110/872/059/1/1108720591.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.105392,
     "geom:longitude":48.203693,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062e\u0641\u062c\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkhafji",
     "meso:name_loc":"\u0627\u0644\u062e\u0641\u062c\u064a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062e\u0641\u062c\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":28.230444,
     "mps:longitude":48.216406,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720591,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Khafji",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/059/1/1108720591.geojson
+++ b/data/110/872/059/1/1108720591.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.105392,
     "geom:longitude":48.203693,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062e\u0641\u062c\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720591,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Khafji",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/059/5/1108720595.geojson
+++ b/data/110/872/059/5/1108720595.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.87063,
     "geom:longitude":47.48261,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062e\u0631\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkharj",
     "meso:name_loc":"\u0627\u0644\u062e\u0631\u062c",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062e\u0631\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.857373,
     "mps:longitude":47.579311,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720595,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Kharj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/059/5/1108720595.geojson
+++ b/data/110/872/059/5/1108720595.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.87063,
     "geom:longitude":47.48261,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062e\u0631\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720595,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Al-Kharj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/059/7/1108720597.geojson
+++ b/data/110/872/059/7/1108720597.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.092087,
     "geom:longitude":50.925713,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062e\u0631\u062e\u064a\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720597,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Kharkhir",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/059/7/1108720597.geojson
+++ b/data/110/872/059/7/1108720597.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.092087,
     "geom:longitude":50.925713,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062e\u0631\u062e\u064a\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkharkhir",
     "meso:name_loc":"\u0627\u0644\u062e\u0631\u062e\u064a\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062e\u0631\u062e\u064a\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.072816,
     "mps:longitude":50.925707,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720597,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Kharkhir",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/059/9/1108720599.geojson
+++ b/data/110/872/059/9/1108720599.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.243408,
     "geom:longitude":50.113868,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062e\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkhubar",
     "meso:name_loc":"\u0627\u0644\u062e\u0628\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062e\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.265858,
     "mps:longitude":50.11461,
     "mz:hierarchy_label":1,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108720599,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445035,
     "wof:name":"Al-Khubar",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/059/9/1108720599.geojson
+++ b/data/110/872/059/9/1108720599.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.243408,
     "geom:longitude":50.113868,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062e\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1108720599,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Khubar",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/060/1/1108720601.geojson
+++ b/data/110/872/060/1/1108720601.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.984396,
     "geom:longitude":42.58965,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062e\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alkhurmah",
     "meso:name_loc":"\u0627\u0644\u062e\u0631\u0645\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062e\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.916391,
     "mps:longitude":42.381798,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720601,
-    "wof:lastmodified":1555220435,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Khurmah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/1/1108720601.geojson
+++ b/data/110/872/060/1/1108720601.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.984396,
     "geom:longitude":42.58965,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062e\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720601,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448407,
     "wof:name":"Al-Khurmah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/3/1108720603.geojson
+++ b/data/110/872/060/3/1108720603.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.424267,
     "geom:longitude":40.405867,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720603,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448407,
     "wof:name":"Al-Lith",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/3/1108720603.geojson
+++ b/data/110/872/060/3/1108720603.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.424267,
     "geom:longitude":40.405867,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Allith",
     "meso:name_loc":"\u0627\u0644\u0644\u064a\u062b",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.501593,
     "mps:longitude":40.339401,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720603,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Lith",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/5/1108720605.geojson
+++ b/data/110/872/060/5/1108720605.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.3231,
     "geom:longitude":39.631858,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720605,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448407,
     "wof:name":"Al-Madinah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/5/1108720605.geojson
+++ b/data/110/872/060/5/1108720605.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.3231,
     "geom:longitude":39.631858,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almadinah almunawwarah",
     "meso:name_loc":"\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.293287,
     "mps:longitude":39.535119,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720605,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Madinah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/7/1108720607.geojson
+++ b/data/110/872/060/7/1108720607.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.532601,
     "geom:longitude":40.946947,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u0647\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720607,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448407,
     "wof:name":"Al-Mahd",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/7/1108720607.geojson
+++ b/data/110/872/060/7/1108720607.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.532601,
     "geom:longitude":40.946947,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u0647\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almahd",
     "meso:name_loc":"\u0627\u0644\u0645\u0647\u062f",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u0647\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.495315,
     "mps:longitude":40.829853,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720607,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Mahd",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/9/1108720609.geojson
+++ b/data/110/872/060/9/1108720609.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.000829,
     "geom:longitude":41.823954,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u062c\u0627\u0631\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720609,
-    "wof:lastmodified":1560445038,
+    "wof:lastmodified":1560448406,
     "wof:name":"Al-Majardah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/060/9/1108720609.geojson
+++ b/data/110/872/060/9/1108720609.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.000829,
     "geom:longitude":41.823954,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u062c\u0627\u0631\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almajardah",
     "meso:name_loc":"\u0627\u0644\u0645\u062c\u0627\u0631\u062f\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u062c\u0627\u0631\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.96875,
     "mps:longitude":41.818495,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720609,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445038,
     "wof:name":"Al-Majardah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/061/3/1108720613.geojson
+++ b/data/110/872/061/3/1108720613.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.405012,
     "geom:longitude":45.636363,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u062c\u0645\u0639\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720613,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Majmaah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/061/3/1108720613.geojson
+++ b/data/110/872/061/3/1108720613.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.405012,
     "geom:longitude":45.636363,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u062c\u0645\u0639\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almajmaah",
     "meso:name_loc":"\u0627\u0644\u0645\u062c\u0645\u0639\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u062c\u0645\u0639\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.416618,
     "mps:longitude":45.632469,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720613,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445034,
     "wof:name":"Al-Majmaah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/061/5/1108720615.geojson
+++ b/data/110/872/061/5/1108720615.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.199065,
     "geom:longitude":41.273265,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u0646\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almandaq",
     "meso:name_loc":"\u0627\u0644\u0645\u0646\u062f\u0642",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u0646\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.112426,
     "mps:longitude":41.328747,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720615,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445034,
     "wof:name":"Al-Mandaq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/061/5/1108720615.geojson
+++ b/data/110/872/061/5/1108720615.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.199065,
     "geom:longitude":41.273265,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u0646\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720615,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Mandaq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/061/7/1108720617.geojson
+++ b/data/110/872/061/7/1108720617.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.653354,
     "geom:longitude":44.148821,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u0630\u0646\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almidhnab",
     "meso:name_loc":"\u0627\u0644\u0645\u0630\u0646\u0628",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u0630\u0646\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.496089,
     "mps:longitude":43.992456,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720617,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445034,
     "wof:name":"Al-Midhnab",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/061/7/1108720617.geojson
+++ b/data/110/872/061/7/1108720617.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.653354,
     "geom:longitude":44.148821,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u0630\u0646\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720617,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Midhnab",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/061/9/1108720619.geojson
+++ b/data/110/872/061/9/1108720619.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.699784,
     "geom:longitude":41.363745,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u062e\u0648\u0627\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almukhwah",
     "meso:name_loc":"\u0627\u0644\u0645\u062e\u0648\u0627\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u062e\u0648\u0627\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.681712,
     "mps:longitude":41.39673,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720619,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445034,
     "wof:name":"Al-Mukhwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/061/9/1108720619.geojson
+++ b/data/110/872/061/9/1108720619.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.699784,
     "geom:longitude":41.363745,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u062e\u0648\u0627\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720619,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Al-Mukhwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/062/1/1108720621.geojson
+++ b/data/110/872/062/1/1108720621.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.131731,
     "geom:longitude":46.254391,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Almuzahimiyah",
     "meso:name_loc":"\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.183295,
     "mps:longitude":46.246002,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720621,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445029,
     "wof:name":"Al-Muzahimiya",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/062/1/1108720621.geojson
+++ b/data/110/872/062/1/1108720621.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.131731,
     "geom:longitude":46.254391,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720621,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Al-Muzahimiya",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/062/3/1108720623.geojson
+++ b/data/110/872/062/3/1108720623.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.962133,
     "geom:longitude":48.522671,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0646\u0639\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720623,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Al-Nuayriyah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/062/3/1108720623.geojson
+++ b/data/110/872/062/3/1108720623.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.962133,
     "geom:longitude":48.522671,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0646\u0639\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alnuayriyah",
     "meso:name_loc":"\u0646\u0639\u064a\u0631\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0646\u0639\u064a\u0631\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.064409,
     "mps:longitude":48.475566,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720623,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445029,
     "wof:name":"Al-Nuayriyah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/062/5/1108720625.geojson
+++ b/data/110/872/062/5/1108720625.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.463879,
     "geom:longitude":41.347314,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0642\u0631\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alqari",
     "meso:name_loc":"\u0627\u0644\u0642\u0631\u0649",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0642\u0631\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.433013,
     "mps:longitude":41.328663,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720625,
-    "wof:lastmodified":1555220436,
+    "wof:lastmodified":1560445029,
     "wof:name":"Al-Qari",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/062/5/1108720625.geojson
+++ b/data/110/872/062/5/1108720625.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.463879,
     "geom:longitude":41.347314,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0642\u0631\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720625,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Al-Qari",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/062/7/1108720627.geojson
+++ b/data/110/872/062/7/1108720627.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.627709,
     "geom:longitude":49.920851,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0642\u0637\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alqatif",
     "meso:name_loc":"\u0627\u0644\u0642\u0637\u064a\u0641",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0642\u0637\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.619482,
     "mps:longitude":49.920864,
     "mz:hierarchy_label":1,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108720627,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445029,
     "wof:name":"Al-Qatif",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/062/7/1108720627.geojson
+++ b/data/110/872/062/7/1108720627.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.627709,
     "geom:longitude":49.920851,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0642\u0637\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1108720627,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Al-Qatif",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/063/1/1108720631.geojson
+++ b/data/110/872/063/1/1108720631.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.75224,
     "geom:longitude":42.202145,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u062f\u0631\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alqiyas",
     "meso:name_loc":"\u0627\u0644\u062f\u0631\u0628",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u062f\u0631\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.7535,
     "mps:longitude":42.198009,
     "mz:hierarchy_label":1,
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108720631,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445031,
     "wof:name":"Alddarb",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/063/1/1108720631.geojson
+++ b/data/110/872/063/1/1108720631.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.75224,
     "geom:longitude":42.202145,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u062f\u0631\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":1108720631,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Alddarb",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/063/3/1108720633.geojson
+++ b/data/110/872/063/3/1108720633.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.254243,
     "geom:longitude":41.389674,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0642\u0646\u0641\u0630\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alqunfidhah",
     "meso:name_loc":"\u0627\u0644\u0642\u0646\u0641\u0630\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0642\u0646\u0641\u0630\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.221792,
     "mps:longitude":41.351113,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720633,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445031,
     "wof:name":"Al-Qunfidhah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/063/3/1108720633.geojson
+++ b/data/110/872/063/3/1108720633.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.254243,
     "geom:longitude":41.389674,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0642\u0646\u0641\u0630\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720633,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Al-Qunfidhah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/063/5/1108720635.geojson
+++ b/data/110/872/063/5/1108720635.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":31.068534,
     "geom:longitude":37.841154,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0642\u0631\u064a\u0627\u062a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720635,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Al-Qurayyat",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/063/5/1108720635.geojson
+++ b/data/110/872/063/5/1108720635.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":31.068534,
     "geom:longitude":37.841154,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0642\u0631\u064a\u0627\u062a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alqurayyat",
     "meso:name_loc":"\u0627\u0644\u0642\u0631\u064a\u0627\u062a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0642\u0631\u064a\u0627\u062a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":31.347366,
     "mps:longitude":37.637478,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720635,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445031,
     "wof:name":"Al-Qurayyat",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/063/7/1108720637.geojson
+++ b/data/110/872/063/7/1108720637.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.211908,
     "geom:longitude":44.651158,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0642\u0648\u064a\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alquwayiyah",
     "meso:name_loc":"\u0627\u0644\u0642\u0648\u064a\u0639\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0642\u0648\u064a\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.136481,
     "mps:longitude":44.786656,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720637,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445031,
     "wof:name":"Al-Quwayiyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/063/7/1108720637.geojson
+++ b/data/110/872/063/7/1108720637.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.211908,
     "geom:longitude":44.651158,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0642\u0648\u064a\u0639\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720637,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Al-Quwayiyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/063/9/1108720639.geojson
+++ b/data/110/872/063/9/1108720639.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.229407,
     "geom:longitude":41.416884,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0637\u0627\u0626\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Altaif",
     "meso:name_loc":"\u0627\u0644\u0637\u0627\u0626\u0641",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0637\u0627\u0626\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":22.422107,
     "mps:longitude":41.437315,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720639,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445031,
     "wof:name":"Al-Taif",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/063/9/1108720639.geojson
+++ b/data/110/872/063/9/1108720639.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.229407,
     "geom:longitude":41.416884,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0637\u0627\u0626\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720639,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"Al-Taif",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/064/1/1108720641.geojson
+++ b/data/110/872/064/1/1108720641.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.536694,
     "geom:longitude":37.90926,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0639\u0644\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alula",
     "meso:name_loc":"\u0627\u0644\u0639\u0644\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0639\u0644\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.523779,
     "mps:longitude":37.926924,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720641,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445032,
     "wof:name":"Alula",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/064/1/1108720641.geojson
+++ b/data/110/872/064/1/1108720641.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.536694,
     "geom:longitude":37.90926,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0639\u0644\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720641,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Alula",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/064/3/1108720643.geojson
+++ b/data/110/872/064/3/1108720643.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.430184,
     "geom:longitude":36.822168,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0648\u062c\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Alwajh",
     "meso:name_loc":"\u0627\u0644\u0648\u062c\u0647",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0648\u062c\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.426687,
     "mps:longitude":36.748109,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720643,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445032,
     "wof:name":"Al-Wajh",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/064/3/1108720643.geojson
+++ b/data/110/872/064/3/1108720643.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.430184,
     "geom:longitude":36.822168,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0648\u062c\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720643,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Al-Wajh",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/064/5/1108720645.geojson
+++ b/data/110/872/064/5/1108720645.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.516345,
     "geom:longitude":42.660117,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0646\u0628\u0647\u0627\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720645,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"An-Nabhaniyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/064/5/1108720645.geojson
+++ b/data/110/872/064/5/1108720645.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.516345,
     "geom:longitude":42.660117,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0646\u0628\u0647\u0627\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Annabhaniyah",
     "meso:name_loc":"\u0627\u0644\u0646\u0628\u0647\u0627\u0646\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0646\u0628\u0647\u0627\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.493357,
     "mps:longitude":42.879214,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720645,
-    "wof:lastmodified":1555220437,
+    "wof:lastmodified":1560445032,
     "wof:name":"An-Nabhaniyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/064/9/1108720649.geojson
+++ b/data/110/872/064/9/1108720649.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.262905,
     "geom:longitude":42.254683,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0646\u0645\u0627\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720649,
-    "wof:lastmodified":1560445031,
+    "wof:lastmodified":1560448400,
     "wof:name":"An-Namas",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/064/9/1108720649.geojson
+++ b/data/110/872/064/9/1108720649.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.262905,
     "geom:longitude":42.254683,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0646\u0645\u0627\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Annamas",
     "meso:name_loc":"\u0627\u0644\u0646\u0645\u0627\u0635",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0646\u0645\u0627\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.20698,
     "mps:longitude":42.220049,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720649,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445031,
     "wof:name":"An-Namas",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/065/1/1108720651.geojson
+++ b/data/110/872/065/1/1108720651.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":30.725434,
     "geom:longitude":41.35207,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0639\u0631\u0639\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Arar",
     "meso:name_loc":"\u0639\u0631\u0639\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0639\u0631\u0639\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":31.304422,
     "mps:longitude":40.616954,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720651,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445029,
     "wof:name":"Ar'ar",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/065/1/1108720651.geojson
+++ b/data/110/872/065/1/1108720651.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":30.725434,
     "geom:longitude":41.35207,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0639\u0631\u0639\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720651,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448397,
     "wof:name":"Ar'ar",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/065/3/1108720653.geojson
+++ b/data/110/872/065/3/1108720653.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.075152,
     "geom:longitude":42.9194,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0631\u0633 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720653,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Ar-Rass",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/065/3/1108720653.geojson
+++ b/data/110/872/065/3/1108720653.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.075152,
     "geom:longitude":42.9194,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0631\u0633 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Arrass",
     "meso:name_loc":"\u0627\u0644\u0631\u0633",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0631\u0633 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.834624,
     "mps:longitude":42.736323,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720653,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445029,
     "wof:name":"Ar-Rass",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/065/5/1108720655.geojson
+++ b/data/110/872/065/5/1108720655.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.645806,
     "geom:longitude":42.826936,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0631\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720655,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448398,
     "wof:name":"Ar-Rayth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/065/5/1108720655.geojson
+++ b/data/110/872/065/5/1108720655.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.645806,
     "geom:longitude":42.826936,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0631\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Arrayth",
     "meso:name_loc":"\u0627\u0644\u0631\u064a\u062b",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0631\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.654101,
     "mps:longitude":42.785488,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720655,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445029,
     "wof:name":"Ar-Rayth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/065/7/1108720657.geojson
+++ b/data/110/872/065/7/1108720657.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.732534,
     "geom:longitude":46.552039,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0631\u064a\u0627\u0636 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Arriyad",
     "meso:name_loc":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0631\u064a\u0627\u0636 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.686556,
     "mps:longitude":47.198542,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720657,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445029,
     "wof:name":"Ar-Riyad",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/065/7/1108720657.geojson
+++ b/data/110/872/065/7/1108720657.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.732534,
     "geom:longitude":46.552039,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0631\u064a\u0627\u0636 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720657,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448396,
     "wof:name":"Ar-Riyad",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/065/9/1108720659.geojson
+++ b/data/110/872/065/9/1108720659.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.00124,
     "geom:longitude":44.470916,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0634\u0645\u0627\u0633\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Ashshimasiyah",
     "meso:name_loc":"\u0627\u0644\u0634\u0645\u0627\u0633\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0634\u0645\u0627\u0633\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.718899,
     "mps:longitude":44.613121,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720659,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445029,
     "wof:name":"Ash-Shimasiyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/065/9/1108720659.geojson
+++ b/data/110/872/065/9/1108720659.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.00124,
     "geom:longitude":44.470916,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0634\u0645\u0627\u0633\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720659,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448396,
     "wof:name":"Ash-Shimasiyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/066/1/1108720661.geojson
+++ b/data/110/872/066/1/1108720661.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.094791,
     "geom:longitude":42.447799,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0634\u0646\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720661,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"As-Shinan",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/066/1/1108720661.geojson
+++ b/data/110/872/066/1/1108720661.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.094791,
     "geom:longitude":42.447799,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0634\u0646\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Asshinan",
     "meso:name_loc":"\u0627\u0644\u0634\u0646\u0627\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0634\u0646\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.995719,
     "mps:longitude":42.434627,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720661,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445034,
     "wof:name":"As-Shinan",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/066/3/1108720663.geojson
+++ b/data/110/872/066/3/1108720663.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.288098,
     "geom:longitude":46.452429,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0633\u0644\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Assulayyil",
     "meso:name_loc":"\u0627\u0644\u0633\u0644\u064a\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0633\u0644\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.224606,
     "mps:longitude":46.422287,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720663,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445034,
     "wof:name":"As-Sulayyil",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/3/1108720663.geojson
+++ b/data/110/872/066/3/1108720663.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.288098,
     "geom:longitude":46.452429,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0633\u0644\u064a\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720663,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"As-Sulayyil",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/7/1108720667.geojson
+++ b/data/110/872/066/7/1108720667.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.524419,
     "geom:longitude":44.692572,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0644\u0632\u0644\u0641\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720667,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Az-Zulfi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/7/1108720667.geojson
+++ b/data/110/872/066/7/1108720667.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.524419,
     "geom:longitude":44.692572,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0632\u0644\u0641\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Azzulfi",
     "meso:name_loc":"\u0627\u0644\u0632\u0644\u0641\u0649",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0644\u0632\u0644\u0641\u0649 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.529196,
     "mps:longitude":44.685742,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720667,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445034,
     "wof:name":"Az-Zulfi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/9/1108720669.geojson
+++ b/data/110/872/066/9/1108720669.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.821645,
     "geom:longitude":43.75346,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u062f\u0631 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720669,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Badr al-Janub",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/066/9/1108720669.geojson
+++ b/data/110/872/066/9/1108720669.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.821645,
     "geom:longitude":43.75346,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u062f\u0631 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Badr aljanub",
     "meso:name_loc":"\u0628\u062f\u0631 \u0627\u0644\u062c\u0646\u0648\u0628",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u062f\u0631 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.82496,
     "mps:longitude":43.739873,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720669,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445034,
     "wof:name":"Badr al-Janub",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/067/1/1108720671.geojson
+++ b/data/110/872/067/1/1108720671.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.778186,
     "geom:longitude":38.972967,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u062f\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Badr",
     "meso:name_loc":"\u0628\u062f\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u062f\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.753404,
     "mps:longitude":38.934264,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720671,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445037,
     "wof:name":"Badr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/067/1/1108720671.geojson
+++ b/data/110/872/067/1/1108720671.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.778186,
     "geom:longitude":38.972967,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u062f\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720671,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Badr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/067/3/1108720673.geojson
+++ b/data/110/872/067/3/1108720673.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.711788,
     "geom:longitude":41.945468,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u0627\u0644\u0642\u0631\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720673,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Balqarn",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/067/3/1108720673.geojson
+++ b/data/110/872/067/3/1108720673.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.711788,
     "geom:longitude":41.945468,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0627\u0644\u0642\u0631\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Balqarn",
     "meso:name_loc":"\u0628\u0627\u0644\u0642\u0631\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u0627\u0644\u0642\u0631\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.71656,
     "mps:longitude":41.948941,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720673,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445037,
     "wof:name":"Balqarn",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/067/5/1108720675.geojson
+++ b/data/110/872/067/5/1108720675.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.079146,
     "geom:longitude":42.898108,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0642\u0639\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Baqa",
     "meso:name_loc":"\u0628\u0642\u0639\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u0642\u0639\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.913871,
     "mps:longitude":42.878568,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720675,
-    "wof:lastmodified":1555220438,
+    "wof:lastmodified":1560445037,
     "wof:name":"Baqa",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/067/5/1108720675.geojson
+++ b/data/110/872/067/5/1108720675.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.079146,
     "geom:longitude":42.898108,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u0642\u0639\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720675,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Baqa",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/067/7/1108720677.geojson
+++ b/data/110/872/067/7/1108720677.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.522887,
     "geom:longitude":42.502081,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720677,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448406,
     "wof:name":"Baysh",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/067/7/1108720677.geojson
+++ b/data/110/872/067/7/1108720677.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.522887,
     "geom:longitude":42.502081,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Baysh",
     "meso:name_loc":"\u0628\u064a\u0634",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u064a\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.506229,
     "mps:longitude":42.56726,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720677,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445037,
     "wof:name":"Baysh",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/067/9/1108720679.geojson
+++ b/data/110/872/067/9/1108720679.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.001814,
     "geom:longitude":41.731126,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u0644\u062c\u0631\u0634\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720679,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448405,
     "wof:name":"Biljurashi",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/067/9/1108720679.geojson
+++ b/data/110/872/067/9/1108720679.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.001814,
     "geom:longitude":41.731126,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0644\u062c\u0631\u0634\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Biljurashi",
     "meso:name_loc":"\u0628\u0644\u062c\u0631\u0634\u064a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u0644\u062c\u0631\u0634\u064a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.93521,
     "mps:longitude":41.688105,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720679,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445037,
     "wof:name":"Biljurashi",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/068/1/1108720681.geojson
+++ b/data/110/872/068/1/1108720681.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.836604,
     "geom:longitude":42.56768,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u064a\u0634\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Bishah",
     "meso:name_loc":"\u0628\u064a\u0634\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u064a\u0634\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.883798,
     "mps:longitude":42.577028,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720681,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445036,
     "wof:name":"Bishah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/068/1/1108720681.geojson
+++ b/data/110/872/068/1/1108720681.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.836604,
     "geom:longitude":42.56768,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u064a\u0634\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720681,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448404,
     "wof:name":"Bishah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/068/5/1108720685.geojson
+++ b/data/110/872/068/5/1108720685.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.067349,
     "geom:longitude":49.546259,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720685,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Buqayq",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/068/5/1108720685.geojson
+++ b/data/110/872/068/5/1108720685.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.067349,
     "geom:longitude":49.546259,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Buqayq",
     "meso:name_loc":"\u0628\u0642\u064a\u0642",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u0642\u064a\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.06287,
     "mps:longitude":49.546218,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720685,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445036,
     "wof:name":"Buqayq",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/068/7/1108720687.geojson
+++ b/data/110/872/068/7/1108720687.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.646941,
     "geom:longitude":43.504925,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0631\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Buraydah",
     "meso:name_loc":"\u0628\u0631\u064a\u062f\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0628\u0631\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.550483,
     "mps:longitude":44.334373,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720687,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445035,
     "wof:name":"Buraydah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/068/7/1108720687.geojson
+++ b/data/110/872/068/7/1108720687.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.646941,
     "geom:longitude":43.504925,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0628\u0631\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720687,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Buraydah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/068/9/1108720689.geojson
+++ b/data/110/872/068/9/1108720689.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.130753,
     "geom:longitude":42.823441,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0636\u0645\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Damad",
     "meso:name_loc":"\u0636\u0645\u062f",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0636\u0645\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.132878,
     "mps:longitude":42.825498,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720689,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445035,
     "wof:name":"Damad",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/068/9/1108720689.geojson
+++ b/data/110/872/068/9/1108720689.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.130753,
     "geom:longitude":42.823441,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0636\u0645\u062f \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720689,
-    "wof:lastmodified":1560445035,
+    "wof:lastmodified":1560448404,
     "wof:name":"Damad",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/069/1/1108720691.geojson
+++ b/data/110/872/069/1/1108720691.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.390354,
     "geom:longitude":39.532097,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062f\u0648\u0645\u0629 \u0627\u0644\u062c\u0646\u062f\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720691,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Dawamat al-Jandal",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/069/1/1108720691.geojson
+++ b/data/110/872/069/1/1108720691.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.390354,
     "geom:longitude":39.532097,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062f\u0648\u0645\u0629 \u0627\u0644\u062c\u0646\u062f\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Dawamat aljandal",
     "meso:name_loc":"\u062f\u0648\u0645\u0629 \u0627\u0644\u062c\u0646\u062f\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062f\u0648\u0645\u0629 \u0627\u0644\u062c\u0646\u062f\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":29.312923,
     "mps:longitude":39.515169,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720691,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445036,
     "wof:name":"Dawamat al-Jandal",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/069/3/1108720693.geojson
+++ b/data/110/872/069/3/1108720693.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.52694,
     "geom:longitude":35.991984,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0636\u0628\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Duba",
     "meso:name_loc":"\u0636\u0628\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0636\u0628\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.395341,
     "mps:longitude":36.13317,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720693,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445037,
     "wof:name":"Duba",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/069/3/1108720693.geojson
+++ b/data/110/872/069/3/1108720693.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.52694,
     "geom:longitude":35.991984,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0636\u0628\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720693,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448405,
     "wof:name":"Duba",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/069/5/1108720695.geojson
+++ b/data/110/872/069/5/1108720695.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.663771,
     "geom:longitude":46.099291,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0636\u0631\u0645\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Duruma",
     "meso:name_loc":"\u0636\u0631\u0645\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0636\u0631\u0645\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.685166,
     "mps:longitude":46.092138,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720695,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445037,
     "wof:name":"Duruma",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/069/5/1108720695.geojson
+++ b/data/110/872/069/5/1108720695.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.663771,
     "geom:longitude":46.099291,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0636\u0631\u0645\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720695,
-    "wof:lastmodified":1560445037,
+    "wof:lastmodified":1560448405,
     "wof:name":"Duruma",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/069/7/1108720697.geojson
+++ b/data/110/872/069/7/1108720697.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.783139,
     "geom:longitude":41.936899,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0641\u0631\u0633\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Farasan",
     "meso:name_loc":"\u0641\u0631\u0633\u0627\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0641\u0631\u0633\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.7211,
     "mps:longitude":41.99218,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720697,
-    "wof:lastmodified":1555220439,
+    "wof:lastmodified":1560445036,
     "wof:name":"Farasan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/069/7/1108720697.geojson
+++ b/data/110/872/069/7/1108720697.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.783139,
     "geom:longitude":41.936899,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0641\u0631\u0633\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720697,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Farasan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/069/9/1108720699.geojson
+++ b/data/110/872/069/9/1108720699.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.254852,
     "geom:longitude":46.080999,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0641\u0631 \u0627\u0644\u0628\u0627\u0637\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720699,
-    "wof:lastmodified":1560445036,
+    "wof:lastmodified":1560448405,
     "wof:name":"Hafar al-Batin",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/069/9/1108720699.geojson
+++ b/data/110/872/069/9/1108720699.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.254852,
     "geom:longitude":46.080999,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0641\u0631 \u0627\u0644\u0628\u0627\u0637\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Hafar albatin",
     "meso:name_loc":"\u062d\u0641\u0631 \u0627\u0644\u0628\u0627\u0637\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0641\u0631 \u0627\u0644\u0628\u0627\u0637\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":28.449154,
     "mps:longitude":46.2461,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720699,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445036,
     "wof:name":"Hafar al-Batin",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/070/3/1108720703.geojson
+++ b/data/110/872/070/3/1108720703.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.758772,
     "geom:longitude":40.769777,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720703,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Ha'il",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/070/3/1108720703.geojson
+++ b/data/110/872/070/3/1108720703.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.758772,
     "geom:longitude":40.769777,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Hail",
     "meso:name_loc":"\u062d\u0627\u0626\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":28.025514,
     "mps:longitude":40.746181,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720703,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Ha'il",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/070/5/1108720705.geojson
+++ b/data/110/872/070/5/1108720705.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.008804,
     "geom:longitude":35.357235,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0642\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Haqil",
     "meso:name_loc":"\u062d\u0642\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0642\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":28.99887,
     "mps:longitude":35.572248,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720705,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Haqil",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/070/5/1108720705.geojson
+++ b/data/110/872/070/5/1108720705.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.008804,
     "geom:longitude":35.357235,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0642\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720705,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Haqil",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/070/7/1108720707.geojson
+++ b/data/110/872/070/7/1108720707.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.222918,
     "geom:longitude":46.693413,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0648\u0637\u0629 \u0628\u0646\u064a \u062a\u0645\u064a\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720707,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Hawtat Bani Tamim",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/070/7/1108720707.geojson
+++ b/data/110/872/070/7/1108720707.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":23.222918,
     "geom:longitude":46.693413,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0648\u0637\u0629 \u0628\u0646\u064a \u062a\u0645\u064a\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Hawtat Bani Tamim",
     "meso:name_loc":"\u062d\u0648\u0637\u0629 \u0628\u0646\u064a \u062a\u0645\u064a\u0645",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0648\u0637\u0629 \u0628\u0646\u064a \u062a\u0645\u064a\u0645 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":23.181029,
     "mps:longitude":46.809811,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720707,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Hawtat Bani Tamim",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/070/9/1108720709.geojson
+++ b/data/110/872/070/9/1108720709.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.783341,
     "geom:longitude":44.211706,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0628\u0648\u0646\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Hubuna",
     "meso:name_loc":"\u062d\u0628\u0648\u0646\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0628\u0648\u0646\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.757697,
     "mps:longitude":44.333601,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720709,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Hubuna",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/070/9/1108720709.geojson
+++ b/data/110/872/070/9/1108720709.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.783341,
     "geom:longitude":44.211706,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0628\u0648\u0646\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720709,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Hubuna",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/071/1/1108720711.geojson
+++ b/data/110/872/071/1/1108720711.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.214915,
     "geom:longitude":46.248677,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062d\u0631\u064a\u0645\u0644\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720711,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Huraymila",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/071/1/1108720711.geojson
+++ b/data/110/872/071/1/1108720711.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.214915,
     "geom:longitude":46.248677,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062d\u0631\u064a\u0645\u0644\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Huraymila",
     "meso:name_loc":"\u062d\u0631\u064a\u0645\u0644\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062d\u0631\u064a\u0645\u0644\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.235741,
     "mps:longitude":46.327197,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720711,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Huraymila",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/071/3/1108720713.geojson
+++ b/data/110/872/071/3/1108720713.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.060319,
     "geom:longitude":42.825238,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062c\u0627\u0632\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720713,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Jizan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/071/3/1108720713.geojson
+++ b/data/110/872/071/3/1108720713.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.060319,
     "geom:longitude":42.825238,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062c\u0627\u0632\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Jazan",
     "meso:name_loc":"\u062c\u0627\u0632\u0627\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062c\u0627\u0632\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.909952,
     "mps:longitude":42.59584,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720713,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Jizan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/071/5/1108720715.geojson
+++ b/data/110/872/071/5/1108720715.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.654899,
     "geom:longitude":39.199022,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062c\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Jiddah",
     "meso:name_loc":"\u062c\u062f\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062c\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.512486,
     "mps:longitude":39.269666,
     "mz:hierarchy_label":1,
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1108720715,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Jiddah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/071/5/1108720715.geojson
+++ b/data/110/872/071/5/1108720715.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.654899,
     "geom:longitude":39.199022,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062c\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":1108720715,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Jiddah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/071/7/1108720717.geojson
+++ b/data/110/872/071/7/1108720717.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.688004,
     "geom:longitude":42.907195,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062e\u0645\u064a\u0633 \u0645\u0634\u064a\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720717,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Khamis Mushayt",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/071/7/1108720717.geojson
+++ b/data/110/872/071/7/1108720717.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.688004,
     "geom:longitude":42.907195,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062e\u0645\u064a\u0633 \u0645\u0634\u064a\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Khamis Mushayt",
     "meso:name_loc":"\u062e\u0645\u064a\u0633 \u0645\u0634\u064a\u0637",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062e\u0645\u064a\u0633 \u0645\u0634\u064a\u0637 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.705927,
     "mps:longitude":42.825243,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720717,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445027,
     "wof:name":"Khamis Mushayt",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/072/1/1108720721.geojson
+++ b/data/110/872/072/1/1108720721.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.893262,
     "geom:longitude":39.367477,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062e\u064a\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Khaybar",
     "meso:name_loc":"\u062e\u064a\u0628\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062e\u064a\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.795267,
     "mps:longitude":39.443895,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720721,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445034,
     "wof:name":"Khaybar",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/072/1/1108720721.geojson
+++ b/data/110/872/072/1/1108720721.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.893262,
     "geom:longitude":39.367477,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062e\u064a\u0628\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720721,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448402,
     "wof:name":"Khaybar",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/072/3/1108720723.geojson
+++ b/data/110/872/072/3/1108720723.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.662496,
     "geom:longitude":45.266249,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062e\u0628\u0627\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720723,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Khubash",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/072/3/1108720723.geojson
+++ b/data/110/872/072/3/1108720723.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.662496,
     "geom:longitude":45.266249,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062e\u0628\u0627\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Khubash",
     "meso:name_loc":"\u062e\u0628\u0627\u0634",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062e\u0628\u0627\u0634 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.676715,
     "mps:longitude":45.347668,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720723,
-    "wof:lastmodified":1555220440,
+    "wof:lastmodified":1560445034,
     "wof:name":"Khubash",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/072/5/1108720725.geojson
+++ b/data/110/872/072/5/1108720725.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.287293,
     "geom:longitude":39.577284,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062e\u0644\u064a\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Khulays",
     "meso:name_loc":"\u062e\u0644\u064a\u0635",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062e\u0644\u064a\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":22.386346,
     "mps:longitude":39.493786,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720725,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445034,
     "wof:name":"Khulays",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/5/1108720725.geojson
+++ b/data/110/872/072/5/1108720725.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.287293,
     "geom:longitude":39.577284,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062e\u0644\u064a\u0635 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720725,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448403,
     "wof:name":"Khulays",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/7/1108720727.geojson
+++ b/data/110/872/072/7/1108720727.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.228791,
     "geom:longitude":39.830291,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720727,
-    "wof:lastmodified":1560445034,
+    "wof:lastmodified":1560448402,
     "wof:name":"Makka",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/7/1108720727.geojson
+++ b/data/110/872/072/7/1108720727.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.228791,
     "geom:longitude":39.830291,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Makkah almukarramah",
     "meso:name_loc":"\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.175533,
     "mps:longitude":39.821467,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720727,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445034,
     "wof:name":"Makka",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/9/1108720729.geojson
+++ b/data/110/872/072/9/1108720729.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.473494,
     "geom:longitude":41.942376,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0645\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720729,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Muhayil",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/072/9/1108720729.geojson
+++ b/data/110/872/072/9/1108720729.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.473494,
     "geom:longitude":41.942376,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Muhayil",
     "meso:name_loc":"\u0645\u062d\u0627\u0626\u0644",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0645\u062d\u0627\u0626\u0644 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.589917,
     "mps:longitude":41.950799,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720729,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445033,
     "wof:name":"Muhayil",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/073/1/1108720731.geojson
+++ b/data/110/872/073/1/1108720731.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.674735,
     "geom:longitude":46.508115,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0646\u062c\u0631\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Najran",
     "meso:name_loc":"\u0646\u062c\u0631\u0627\u0646",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0646\u062c\u0631\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.835806,
     "mps:longitude":46.995706,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720731,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445032,
     "wof:name":"Najran",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/073/1/1108720731.geojson
+++ b/data/110/872/073/1/1108720731.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.674735,
     "geom:longitude":46.508115,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0646\u062c\u0631\u0627\u0646 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720731,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Najran",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/073/3/1108720733.geojson
+++ b/data/110/872/073/3/1108720733.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.209992,
     "geom:longitude":47.06075,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0642\u0631\u064a\u0629 \u0627\u0644\u0639\u0644\u064a\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720733,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Qaryah al-Ulya",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/073/3/1108720733.geojson
+++ b/data/110/872/073/3/1108720733.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.209992,
     "geom:longitude":47.06075,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0642\u0631\u064a\u0629 \u0627\u0644\u0639\u0644\u064a\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Qaryah alulya",
     "meso:name_loc":"\u0642\u0631\u064a\u0629 \u0627\u0644\u0639\u0644\u064a\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0642\u0631\u064a\u0629 \u0627\u0644\u0639\u0644\u064a\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.277865,
     "mps:longitude":47.083486,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720733,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445032,
     "wof:name":"Qaryah al-Ulya",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/073/5/1108720735.geojson
+++ b/data/110/872/073/5/1108720735.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.021032,
     "geom:longitude":41.108364,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0642\u0644\u0648\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720735,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Qilwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/073/5/1108720735.geojson
+++ b/data/110/872/073/5/1108720735.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":20.021032,
     "geom:longitude":41.108364,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0642\u0644\u0648\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Qilwah",
     "meso:name_loc":"\u0642\u0644\u0648\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0642\u0644\u0648\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":20.027005,
     "mps:longitude":41.108293,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720735,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445032,
     "wof:name":"Qilwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/073/9/1108720739.geojson
+++ b/data/110/872/073/9/1108720739.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.913884,
     "geom:longitude":39.230148,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0627\u0628\u063a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Rabigh",
     "meso:name_loc":"\u0631\u0627\u0628\u063a",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u0627\u0628\u063a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":22.776315,
     "mps:longitude":39.272519,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720739,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445032,
     "wof:name":"Rabigh",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/073/9/1108720739.geojson
+++ b/data/110/872/073/9/1108720739.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":22.913884,
     "geom:longitude":39.230148,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u0627\u0628\u063a \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720739,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Rabigh",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/074/1/1108720741.geojson
+++ b/data/110/872/074/1/1108720741.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.194343,
     "geom:longitude":43.544794,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u0641\u062d\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720741,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Rafha",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/074/1/1108720741.geojson
+++ b/data/110/872/074/1/1108720741.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":29.194343,
     "geom:longitude":43.544794,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0641\u062d\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Rafha",
     "meso:name_loc":"\u0631\u0641\u062d\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u0641\u062d\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":29.357992,
     "mps:longitude":43.217369,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720741,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445033,
     "wof:name":"Rafha",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/074/3/1108720743.geojson
+++ b/data/110/872/074/3/1108720743.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.092314,
     "geom:longitude":42.802703,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Ranyah",
     "meso:name_loc":"\u0631\u0646\u064a\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.057461,
     "mps:longitude":42.787873,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720743,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445033,
     "wof:name":"Ranyah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/074/3/1108720743.geojson
+++ b/data/110/872/074/3/1108720743.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.092314,
     "geom:longitude":42.802703,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u0646\u064a\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720743,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Ranyah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/074/5/1108720745.geojson
+++ b/data/110/872/074/5/1108720745.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.776311,
     "geom:longitude":49.957772,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0623\u0633 \u062a\u0646\u0648\u0631\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Ras Tannurah",
     "meso:name_loc":"\u0631\u0623\u0633 \u062a\u0646\u0648\u0631\u0647",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u0623\u0633 \u062a\u0646\u0648\u0631\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.812164,
     "mps:longitude":49.927229,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720745,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445033,
     "wof:name":"Ras Tannurah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/074/5/1108720745.geojson
+++ b/data/110/872/074/5/1108720745.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.776311,
     "geom:longitude":49.957772,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u0623\u0633 \u062a\u0646\u0648\u0631\u0647 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720745,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Ras Tannurah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/074/7/1108720747.geojson
+++ b/data/110/872/074/7/1108720747.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.098078,
     "geom:longitude":42.143317,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u062c\u0627\u0644 \u0627\u0644\u0645\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Rijal Alma",
     "meso:name_loc":"\u0631\u062c\u0627\u0644 \u0627\u0644\u0645\u0639",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u062c\u0627\u0644 \u0627\u0644\u0645\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.185868,
     "mps:longitude":42.196538,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720747,
-    "wof:lastmodified":1555220441,
+    "wof:lastmodified":1560445033,
     "wof:name":"Rijal Alma",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/074/7/1108720747.geojson
+++ b/data/110/872/074/7/1108720747.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.098078,
     "geom:longitude":42.143317,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u062c\u0627\u0644 \u0627\u0644\u0645\u0639 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720747,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448401,
     "wof:name":"Rijal Alma",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/074/9/1108720749.geojson
+++ b/data/110/872/074/9/1108720749.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.936921,
     "geom:longitude":42.222498,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u064a\u0627\u0636 \u0627\u0644\u062e\u0628\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Riyadh alkhabra",
     "meso:name_loc":"\u0631\u064a\u0627\u0636 \u0627\u0644\u062e\u0628\u0631\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u064a\u0627\u0636 \u0627\u0644\u062e\u0628\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.0239,
     "mps:longitude":42.349695,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720749,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445032,
     "wof:name":"Riyadh al-Khabra",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/074/9/1108720749.geojson
+++ b/data/110/872/074/9/1108720749.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.936921,
     "geom:longitude":42.222498,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u064a\u0627\u0636 \u0627\u0644\u062e\u0628\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720749,
-    "wof:lastmodified":1560445032,
+    "wof:lastmodified":1560448401,
     "wof:name":"Riyadh al-Khabra",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/075/1/1108720751.geojson
+++ b/data/110/872/075/1/1108720751.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.744421,
     "geom:longitude":47.074405,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0645\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Rumah",
     "meso:name_loc":"\u0631\u0645\u0627\u062d",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0631\u0645\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.731793,
     "mps:longitude":47.130991,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720751,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445033,
     "wof:name":"Rumah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/075/1/1108720751.geojson
+++ b/data/110/872/075/1/1108720751.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.744421,
     "geom:longitude":47.074405,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0631\u0645\u0627\u062d \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720751,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Rumah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/075/3/1108720753.geojson
+++ b/data/110/872/075/3/1108720753.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.241819,
     "geom:longitude":42.638389,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0635\u0628\u064a\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Sabya",
     "meso:name_loc":"\u0635\u0628\u064a\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0635\u0628\u064a\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.239692,
     "mps:longitude":42.634366,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720753,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445033,
     "wof:name":"Sabya",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/075/3/1108720753.geojson
+++ b/data/110/872/075/3/1108720753.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.241819,
     "geom:longitude":42.638389,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0635\u0628\u064a\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720753,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Sabya",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/075/7/1108720757.geojson
+++ b/data/110/872/075/7/1108720757.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":30.137501,
     "geom:longitude":39.939805,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0633\u0643\u0627\u0643\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Sakaka",
     "meso:name_loc":"\u0633\u0643\u0627\u0643\u0627",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0633\u0643\u0627\u0643\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":30.235515,
     "mps:longitude":40.466343,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720757,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445033,
     "wof:name":"Sakaka",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/075/7/1108720757.geojson
+++ b/data/110/872/075/7/1108720757.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":30.137501,
     "geom:longitude":39.939805,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0633\u0643\u0627\u0643\u0627 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720757,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Sakaka",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/075/9/1108720759.geojson
+++ b/data/110/872/075/9/1108720759.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.570418,
     "geom:longitude":42.934601,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0635\u0627\u0645\u0637\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720759,
-    "wof:lastmodified":1560445033,
+    "wof:lastmodified":1560448402,
     "wof:name":"Samtah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/075/9/1108720759.geojson
+++ b/data/110/872/075/9/1108720759.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":16.570418,
     "geom:longitude":42.934601,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0635\u0627\u0645\u0637\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Samtah",
     "meso:name_loc":"\u0635\u0627\u0645\u0637\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0635\u0627\u0645\u0637\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":16.605644,
     "mps:longitude":42.995325,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720759,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445033,
     "wof:name":"Samtah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/076/1/1108720761.geojson
+++ b/data/110/872/076/1/1108720761.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.978621,
     "geom:longitude":43.160805,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0633\u0631\u0627\u0629 \u0639\u0628\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720761,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448391,
     "wof:name":"Sarat Abidah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/076/1/1108720761.geojson
+++ b/data/110/872/076/1/1108720761.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.978621,
     "geom:longitude":43.160805,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0633\u0631\u0627\u0629 \u0639\u0628\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Sarat Abidah",
     "meso:name_loc":"\u0633\u0631\u0627\u0629 \u0639\u0628\u064a\u062f\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0633\u0631\u0627\u0629 \u0639\u0628\u064a\u062f\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.815844,
     "mps:longitude":43.115042,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720761,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445028,
     "wof:name":"Sarat Abidah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/076/3/1108720763.geojson
+++ b/data/110/872/076/3/1108720763.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.375748,
     "geom:longitude":45.136995,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0634\u0642\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Shaqra",
     "meso:name_loc":"\u0634\u0642\u0631\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0634\u0642\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.363164,
     "mps:longitude":45.128718,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720763,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445028,
     "wof:name":"Shaqra",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/076/3/1108720763.geojson
+++ b/data/110/872/076/3/1108720763.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.375748,
     "geom:longitude":45.136995,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0634\u0642\u0631\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720763,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448391,
     "wof:name":"Shaqra",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/076/5/1108720765.geojson
+++ b/data/110/872/076/5/1108720765.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.380328,
     "geom:longitude":47.430537,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0634\u0631\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720765,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448392,
     "wof:name":"Sharurah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/076/5/1108720765.geojson
+++ b/data/110/872/076/5/1108720765.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.380328,
     "geom:longitude":47.430537,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0634\u0631\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Sharurah",
     "meso:name_loc":"\u0634\u0631\u0648\u0631\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0634\u0631\u0648\u0631\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.762622,
     "mps:longitude":47.189645,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720765,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445028,
     "wof:name":"Sharurah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/076/7/1108720767.geojson
+++ b/data/110/872/076/7/1108720767.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.686343,
     "geom:longitude":36.854245,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062a\u0628\u0648\u0643 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720767,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448391,
     "wof:name":"Tabuk",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/076/7/1108720767.geojson
+++ b/data/110/872/076/7/1108720767.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":28.686343,
     "geom:longitude":36.854245,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062a\u0628\u0648\u0643 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Tabuk",
     "meso:name_loc":"\u062a\u0628\u0648\u0643",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062a\u0628\u0648\u0643 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":28.66194,
     "mps:longitude":36.647244,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720767,
-    "wof:lastmodified":1555220442,
+    "wof:lastmodified":1560445028,
     "wof:name":"Tabuk",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/076/9/1108720769.geojson
+++ b/data/110/872/076/9/1108720769.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.616725,
     "geom:longitude":43.626645,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062a\u062b\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720769,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448391,
     "wof:name":"Tathlith",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/076/9/1108720769.geojson
+++ b/data/110/872/076/9/1108720769.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":19.616725,
     "geom:longitude":43.626645,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062a\u062b\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Tathlith",
     "meso:name_loc":"\u062a\u062b\u0644\u064a\u062b",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062a\u062b\u0644\u064a\u062b \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":19.728506,
     "mps:longitude":43.611558,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720769,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445028,
     "wof:name":"Tathlith",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/077/1/1108720771.geojson
+++ b/data/110/872/077/1/1108720771.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.769867,
     "geom:longitude":38.654307,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062a\u064a\u0645\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720771,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Tayma",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/077/1/1108720771.geojson
+++ b/data/110/872/077/1/1108720771.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":27.769867,
     "geom:longitude":38.654307,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062a\u064a\u0645\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Tayma",
     "meso:name_loc":"\u062a\u064a\u0645\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062a\u064a\u0645\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":27.724341,
     "mps:longitude":38.52139,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720771,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445027,
     "wof:name":"Tayma",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/077/5/1108720775.geojson
+++ b/data/110/872/077/5/1108720775.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.505842,
     "geom:longitude":46.041231,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062b\u0627\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720775,
-    "wof:lastmodified":1560445027,
+    "wof:lastmodified":1560448390,
     "wof:name":"Thadiq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/077/5/1108720775.geojson
+++ b/data/110/872/077/5/1108720775.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.505842,
     "geom:longitude":46.041231,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062b\u0627\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Thadiq",
     "meso:name_loc":"\u062b\u0627\u062f\u0642",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062b\u0627\u062f\u0642 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.378369,
     "mps:longitude":45.978065,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720775,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445027,
     "wof:name":"Thadiq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/077/7/1108720777.geojson
+++ b/data/110/872/077/7/1108720777.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.18148,
     "geom:longitude":44.628285,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062b\u0627\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720777,
-    "wof:lastmodified":1560445025,
+    "wof:lastmodified":1560448389,
     "wof:name":"Thar",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/077/7/1108720777.geojson
+++ b/data/110/872/077/7/1108720777.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.18148,
     "geom:longitude":44.628285,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062b\u0627\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Thar",
     "meso:name_loc":"\u062b\u0627\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062b\u0627\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.216181,
     "mps:longitude":44.699485,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720777,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445025,
     "wof:name":"Thar",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/077/9/1108720779.geojson
+++ b/data/110/872/077/9/1108720779.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":31.509582,
     "geom:longitude":39.004458,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0637\u0631\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720779,
-    "wof:lastmodified":1560445025,
+    "wof:lastmodified":1560448389,
     "wof:name":"Turayf",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/077/9/1108720779.geojson
+++ b/data/110/872/077/9/1108720779.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":31.509582,
     "geom:longitude":39.004458,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0637\u0631\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Turayf",
     "meso:name_loc":"\u0637\u0631\u064a\u0641",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0637\u0631\u064a\u0641 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":31.433337,
     "mps:longitude":38.761128,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720779,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445025,
     "wof:name":"Turayf",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/078/1/1108720781.geojson
+++ b/data/110/872/078/1/1108720781.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.22667,
     "geom:longitude":41.598941,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u062a\u0631\u0628\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720781,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448393,
     "wof:name":"Turubah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/078/1/1108720781.geojson
+++ b/data/110/872/078/1/1108720781.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.22667,
     "geom:longitude":41.598941,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u062a\u0631\u0628\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Turubah",
     "meso:name_loc":"\u062a\u0631\u0628\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u062a\u0631\u0628\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.240403,
     "mps:longitude":41.605723,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720781,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445028,
     "wof:name":"Turubah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/078/3/1108720783.geojson
+++ b/data/110/872/078/3/1108720783.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.308725,
     "geom:longitude":37.404664,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0645\u0644\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Umluj",
     "meso:name_loc":"\u0627\u0645\u0644\u062c",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0627\u0645\u0644\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":25.442327,
     "mps:longitude":37.418618,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720783,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445028,
     "wof:name":"Umluj",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/078/3/1108720783.geojson
+++ b/data/110/872/078/3/1108720783.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.308725,
     "geom:longitude":37.404664,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0627\u0645\u0644\u062c \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720783,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448394,
     "wof:name":"Umluj",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/078/5/1108720785.geojson
+++ b/data/110/872/078/5/1108720785.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.94711,
     "geom:longitude":44.01183,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0639\u0646\u064a\u0632\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Unayzah",
     "meso:name_loc":"\u0639\u0646\u064a\u0632\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0639\u0646\u064a\u0632\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.033632,
     "mps:longitude":43.974728,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720785,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445029,
     "wof:name":"Unayzah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/5/1108720785.geojson
+++ b/data/110/872/078/5/1108720785.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":25.94711,
     "geom:longitude":44.01183,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0639\u0646\u064a\u0632\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720785,
-    "wof:lastmodified":1560445029,
+    "wof:lastmodified":1560448395,
     "wof:name":"Unayzah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/7/1108720787.geojson
+++ b/data/110/872/078/7/1108720787.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.681165,
     "geom:longitude":43.234824,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0639\u064a\u0648\u0646 \u0627\u0644\u062c\u0648\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Uyun aljiwa",
     "meso:name_loc":"\u0639\u064a\u0648\u0646 \u0627\u0644\u062c\u0648\u0627\u0621",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0639\u064a\u0648\u0646 \u0627\u0644\u062c\u0648\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":26.750061,
     "mps:longitude":43.10521,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720787,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445028,
     "wof:name":"Uyun al-Jiwa",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/7/1108720787.geojson
+++ b/data/110/872/078/7/1108720787.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":26.681165,
     "geom:longitude":43.234824,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0639\u064a\u0648\u0646 \u0627\u0644\u062c\u0648\u0627\u0621 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720787,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448393,
     "wof:name":"Uyun al-Jiwa",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/9/1108720789.geojson
+++ b/data/110/872/078/9/1108720789.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.057339,
     "geom:longitude":44.606875,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0648\u0627\u062f\u064a \u0627\u0644\u062f\u0648\u0627\u0633\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720789,
-    "wof:lastmodified":1560445028,
+    "wof:lastmodified":1560448392,
     "wof:name":"Wadi ad-Dwasir",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/078/9/1108720789.geojson
+++ b/data/110/872/078/9/1108720789.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":21.057339,
     "geom:longitude":44.606875,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0648\u0627\u062f\u064a \u0627\u0644\u062f\u0648\u0627\u0633\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Wadi addawasir",
     "meso:name_loc":"\u0648\u0627\u062f\u064a \u0627\u0644\u062f\u0648\u0627\u0633\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0648\u0627\u062f\u064a \u0627\u0644\u062f\u0648\u0627\u0633\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":21.113302,
     "mps:longitude":44.390562,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720789,
-    "wof:lastmodified":1555220443,
+    "wof:lastmodified":1560445028,
     "wof:name":"Wadi ad-Dwasir",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/079/3/1108720793.geojson
+++ b/data/110/872/079/3/1108720793.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.848152,
     "geom:longitude":44.717026,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u064a\u062f\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Yadamah",
     "meso:name_loc":"\u064a\u062f\u0645\u0629",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u064a\u062f\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":18.995399,
     "mps:longitude":44.802718,
     "mz:hierarchy_label":1,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108720793,
-    "wof:lastmodified":1555220444,
+    "wof:lastmodified":1560445024,
     "wof:name":"Yadamah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/079/3/1108720793.geojson
+++ b/data/110/872/079/3/1108720793.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":18.848152,
     "geom:longitude":44.717026,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u064a\u062f\u0645\u0629 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720793,
-    "wof:lastmodified":1560445024,
+    "wof:lastmodified":1560448389,
     "wof:name":"Yadamah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/079/5/1108720795.geojson
+++ b/data/110/872/079/5/1108720795.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.748175,
     "geom:longitude":38.234088,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u064a\u0646\u0628\u0639 \u0627\u0644\u0628\u062d\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Yanbu albahr",
     "meso:name_loc":"\u064a\u0646\u0628\u0639 \u0627\u0644\u0628\u062d\u0631",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u064a\u0646\u0628\u0639 \u0627\u0644\u0628\u062d\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":24.660747,
     "mps:longitude":38.424422,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720795,
-    "wof:lastmodified":1555220444,
+    "wof:lastmodified":1560445024,
     "wof:name":"Yanbu al-Bahr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/079/5/1108720795.geojson
+++ b/data/110/872/079/5/1108720795.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":24.748175,
     "geom:longitude":38.234088,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u064a\u0646\u0628\u0639 \u0627\u0644\u0628\u062d\u0631 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720795,
-    "wof:lastmodified":1560445024,
+    "wof:lastmodified":1560448389,
     "wof:name":"Yanbu al-Bahr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/079/7/1108720797.geojson
+++ b/data/110/872/079/7/1108720797.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.869336,
     "geom:longitude":43.516527,
     "iso:country":"SA",
+    "label:ara_x_preferred_longname":[
+        "\u0638\u0647\u0631\u0627\u0646 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
+    ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -31,9 +34,6 @@
     "meso:name_en":"Zahran aljanub",
     "meso:name_loc":"\u0638\u0647\u0631\u0627\u0646 \u0627\u0644\u062c\u0646\u0648\u0628",
     "meso:source":"AOTM",
-    "misc:ara_x_preferred_longname":[
-        "\u0638\u0647\u0631\u0627\u0646 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
-    ],
     "mps:latitude":17.944171,
     "mps:longitude":43.462225,
     "mz:hierarchy_label":1,
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1108720797,
-    "wof:lastmodified":1555220444,
+    "wof:lastmodified":1560445024,
     "wof:name":"Zahran al-Janub",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/079/7/1108720797.geojson
+++ b/data/110/872/079/7/1108720797.geojson
@@ -10,6 +10,9 @@
     "geom:latitude":17.869336,
     "geom:longitude":43.516527,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "mintaqah idariyya"
+    ],
     "label:ara_x_preferred_longname":[
         "\u0638\u0647\u0631\u0627\u0646 \u0627\u0644\u062c\u0646\u0648\u0628 \u0645\u062d\u0627\u0641\u0638\u0627\u062a\u200e"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1108720797,
-    "wof:lastmodified":1560445024,
+    "wof:lastmodified":1560448389,
     "wof:name":"Zahran al-Janub",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/856/768/09/85676809.geojson
+++ b/data/856/768/09/85676809.geojson
@@ -10,11 +10,14 @@
     "geom:latitude":18.450584,
     "geom:longitude":46.867644,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "منطقة نجران"
+        "\u0645\u0646\u0637\u0642\u0629 \u0646\u062c\u0631\u0627\u0646"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Najran Region"
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550486,
+    "wof:lastmodified":1560448387,
     "wof:name":"Najran",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/09/85676809.geojson
+++ b/data/856/768/09/85676809.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":18.450584,
     "geom:longitude":46.867644,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0646\u062c\u0631\u0627\u0646"
+    "label:ara_x_preferred_longname":[
+        "منطقة نجران"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Najran Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Najran Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":18.291272,
     "lbl:longitude":46.580822,

--- a/data/856/768/13/85676813.geojson
+++ b/data/856/768/13/85676813.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":23.08134,
     "geom:longitude":45.586126,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0631\u064a\u0627\u0636"
+    "label:ara_x_preferred_longname":[
+        "منطقة الرياض‎"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Riyadh Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Ar Riyad Region"
+        "Riyadh Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":23.198703,
     "lbl:longitude":45.648245,

--- a/data/856/768/13/85676813.geojson
+++ b/data/856/768/13/85676813.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":33.11639,
-    "geom:area_square_m":376480967449.79895,
+    "geom:area_square_m":376480967449.793579,
     "geom:bbox":"41.6815672747,19.2116735173,48.2370685251,27.7000388669",
     "geom:latitude":23.08134,
     "geom:longitude":45.586126,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "منطقة الرياض‎"
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0631\u064a\u0627\u0636\u200e"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Riyadh Region"
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814821,
+    "wof:lastmodified":1560448388,
     "wof:name":"Ar Riyad",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/19/85676819.geojson
+++ b/data/856/768/19/85676819.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":46.261157,
-    "geom:area_square_m":524880801007.129639,
+    "geom:area_square_m":524880801007.134583,
     "geom:bbox":"44.3664653003,19.0003364153,55.6667,29.1307719878",
     "geom:latitude":23.27921,
     "geom:longitude":50.149936,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "الشرقية‎"
+        "\u0627\u0644\u0634\u0631\u0642\u064a\u0629\u200e"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Eastern Province"
@@ -346,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814822,
+    "wof:lastmodified":1560448386,
     "wof:name":"Eastern Province",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/19/85676819.geojson
+++ b/data/856/768/19/85676819.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":23.27921,
     "geom:longitude":50.149936,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0627\u0644\u0634\u0631\u0642\u064a\u0629"
+    "label:ara_x_preferred_longname":[
+        "الشرقية‎"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Eastern Province"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Eastern Province Region"
+        "Eastern Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":22.531202,
     "lbl:longitude":50.149595,

--- a/data/856/768/25/85676825.geojson
+++ b/data/856/768/25/85676825.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":24.930073,
     "geom:longitude":39.490134,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629"
+    "label:ara_x_preferred_longname":[
+        "المدينة المنورة"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Al Madinah Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Al Madinah Region"
+        "Madinah Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":24.41887,
     "lbl:longitude":39.448885,

--- a/data/856/768/25/85676825.geojson
+++ b/data/856/768/25/85676825.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.456142,
-    "geom:area_square_m":150853674872.87085,
+    "geom:area_square_m":150853674872.8685,
     "geom:bbox":"36.6364745933,22.5234589646,42.1572186196,27.4902522508",
     "geom:latitude":24.930073,
     "geom:longitude":39.490134,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "المدينة المنورة"
+        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Madinah Region"
@@ -343,7 +346,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814822,
+    "wof:lastmodified":1560448388,
     "wof:name":"Al Madinah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/27/85676827.geojson
+++ b/data/856/768/27/85676827.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":26.196343,
     "geom:longitude":43.342925,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0635\u064a\u0645"
+    "label:ara_x_preferred_longname":[
+        "منطقة القصيم"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Al-Qassim Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Al-Qassim Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":26.174592,
     "lbl:longitude":43.370698,

--- a/data/856/768/27/85676827.geojson
+++ b/data/856/768/27/85676827.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.360371,
-    "geom:area_square_m":70561240144.421112,
+    "geom:area_square_m":70561240144.420197,
     "geom:bbox":"41.300329304,24.479960298,44.9842608939,28.2529793596",
     "geom:latitude":26.196343,
     "geom:longitude":43.342925,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "منطقة القصيم"
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0635\u064a\u0645"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Al-Qassim Region"
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814822,
+    "wof:lastmodified":1560448386,
     "wof:name":"Al-Qassim",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/31/85676831.geojson
+++ b/data/856/768/31/85676831.geojson
@@ -10,14 +10,17 @@
     "geom:latitude":27.400807,
     "geom:longitude":41.440619,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "مِنْطَقَة حَائِل"
+        "\u0645\u0650\u0646\u0652\u0637\u064e\u0642\u064e\u0629 \u062d\u064e\u0627\u0626\u0650\u0644"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
-        "Haʾil Region"
+        "Ha\u02beil Region"
     ],
     "label:eng_x_preferred_placetype":[
         "region"
@@ -366,7 +369,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550527,
+    "wof:lastmodified":1560448387,
     "wof:name":"Ha'il",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/31/85676831.geojson
+++ b/data/856/768/31/85676831.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":27.400807,
     "geom:longitude":41.440619,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u062d\u0627\u0626\u0644"
+    "label:ara_x_preferred_longname":[
+        "مِنْطَقَة حَائِل"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Ha'il Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Ha'il Region"
+        "Haʾil Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":27.542875,
     "lbl:longitude":41.401062,

--- a/data/856/768/33/85676833.geojson
+++ b/data/856/768/33/85676833.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.059417,
-    "geom:area_square_m":131757071024.278778,
+    "geom:area_square_m":131757071024.28418,
     "geom:bbox":"34.572917938,24.5665398586,40.0605051217,29.9919113292",
     "geom:latitude":27.901717,
     "geom:longitude":37.257916,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "مِنْطَقَة تَبُوْك‎"
+        "\u0645\u0650\u0646\u0652\u0637\u064e\u0642\u064e\u0629 \u062a\u064e\u0628\u064f\u0648\u0652\u0643\u200e"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Tabuk Region"
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814822,
+    "wof:lastmodified":1560448386,
     "wof:name":"Tabuk",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/33/85676833.geojson
+++ b/data/856/768/33/85676833.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":27.901717,
     "geom:longitude":37.257916,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u062a\u0628\u0648\u0643"
+    "label:ara_x_preferred_longname":[
+        "مِنْطَقَة تَبُوْك‎"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Tabuk Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Tabuk Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":28.585494,
     "lbl:longitude":37.218628,

--- a/data/856/768/37/85676837.geojson
+++ b/data/856/768/37/85676837.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":30.202684,
     "geom:longitude":41.862127,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062d\u062f\u0648\u062f \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+    "label:ara_x_preferred_longname":[
+        "منطقة الحدود الشمالية‎"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Northern Borders Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Northern Borders Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":29.627903,
     "lbl:longitude":42.777988,

--- a/data/856/768/37/85676837.geojson
+++ b/data/856/768/37/85676837.geojson
@@ -10,11 +10,14 @@
     "geom:latitude":30.202684,
     "geom:longitude":41.862127,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "منطقة الحدود الشمالية‎"
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062d\u062f\u0648\u062f \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629\u200e"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Northern Borders Region"
@@ -289,7 +292,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550503,
+    "wof:lastmodified":1560448387,
     "wof:name":"Northern Borders",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/43/85676843.geojson
+++ b/data/856/768/43/85676843.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.158655,
-    "geom:area_square_m":87385803047.175461,
+    "geom:area_square_m":87385803047.175568,
     "geom:bbox":"37.000897,28.3707645538,41.9933668023,31.7497216907",
     "geom:latitude":29.971993,
     "geom:longitude":39.553051,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "منطقة الجوف"
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062c\u0648\u0641"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Al-Jawf Region"
@@ -332,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814823,
+    "wof:lastmodified":1560448387,
     "wof:name":"Al Jawf",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/43/85676843.geojson
+++ b/data/856/768/43/85676843.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":29.971993,
     "geom:longitude":39.553051,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u062c\u0648\u0641"
+    "label:ara_x_preferred_longname":[
+        "منطقة الجوف"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Al Jawf Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Al Jawf Region"
+        "Al-Jawf Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":29.805681,
     "lbl:longitude":39.721926,

--- a/data/856/768/47/85676847.geojson
+++ b/data/856/768/47/85676847.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":20.147198,
     "geom:longitude":41.467053,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0628\u0627\u062d\u0629"
+    "label:ara_x_preferred_longname":[
+        "الباحة"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Al-Bahah Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
-        "Al-Bahah Region"
+        "Al Bahah Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":20.118259,
     "lbl:longitude":41.476799,

--- a/data/856/768/47/85676847.geojson
+++ b/data/856/768/47/85676847.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.956348,
-    "geom:area_square_m":11101671421.99328,
+    "geom:area_square_m":11101671421.993206,
     "geom:bbox":"40.8375343166,19.4460564594,42.1286734231,20.8308645907",
     "geom:latitude":20.147198,
     "geom:longitude":41.467053,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "الباحة"
+        "\u0627\u0644\u0628\u0627\u062d\u0629"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Al Bahah Region"
@@ -333,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814823,
+    "wof:lastmodified":1560448387,
     "wof:name":"Al-Bahah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/51/85676851.geojson
+++ b/data/856/768/51/85676851.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.614145,
-    "geom:area_square_m":77258086888.410828,
+    "geom:area_square_m":77258086888.410843,
     "geom:bbox":"41.3630931215,17.366667,44.4845827283,20.8022925333",
     "geom:latitude":19.137122,
     "geom:longitude":42.942466,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "عَسِيْر"
+        "\u0639\u064e\u0633\u0650\u064a\u0652\u0631"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Aseer Region"
@@ -339,7 +342,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814823,
+    "wof:lastmodified":1560448385,
     "wof:name":"Aseer",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/51/85676851.geojson
+++ b/data/856/768/51/85676851.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":19.137122,
     "geom:longitude":42.942466,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0639\u0633\u064a\u0631"
+    "label:ara_x_preferred_longname":[
+        "عَسِيْر"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Aseer Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Aseer Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":19.125512,
     "lbl:longitude":42.97186,

--- a/data/856/768/53/85676853.geojson
+++ b/data/856/768/53/85676853.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":17.231539,
     "geom:longitude":42.684461,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0646\u0637\u0642\u0629 \u062c\u0627\u0632\u0627\u0646"
+    "label:ara_x_preferred_longname":[
+        "جازان"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Jizan Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Jizan Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":17.312986,
     "lbl:longitude":42.776512,

--- a/data/856/768/53/85676853.geojson
+++ b/data/856/768/53/85676853.geojson
@@ -10,11 +10,14 @@
     "geom:latitude":17.231539,
     "geom:longitude":42.684461,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "جازان"
+        "\u062c\u0627\u0632\u0627\u0646"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Jizan Region"
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550484,
+    "wof:lastmodified":1560448387,
     "wof:name":"Jizan",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/57/85676857.geojson
+++ b/data/856/768/57/85676857.geojson
@@ -14,7 +14,7 @@
         "muhafazah"
     ],
     "label:ara_x_preferred_longname":[
-        "\u0645\u0650\u0640\u0646\u0652\u0640\u0637\u064e\u0640\u0642\u064e\u0640\u0629 \u0645\u064e\u0640\u0643\u064e\u0651\u0640\u0629 \u0627\u0644\u0640\u0645\u064f\u0640\u0643\u064e\u0640\u0631\u064e\u0651\u0645\u064e\u0640\u0629"
+        "\u0645\u0646\u0637\u0642\u0629 \u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629"
     ],
     "label:ara_x_preferred_placetype":[
         "\u0645\u0642\u0627\u0637\u0639\u0629"
@@ -349,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1560448385,
+    "wof:lastmodified":1560455793,
     "wof:name":"Makkah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/57/85676857.geojson
+++ b/data/856/768/57/85676857.geojson
@@ -10,20 +10,17 @@
     "geom:latitude":21.628768,
     "geom:longitude":41.257286,
     "iso:country":"SA",
-    "label:ara_x_placetype_longname":[
-        "\u0645\u0643\u0629 \u0627\u0644\u0645\u0643\u0631\u0645\u0629"
+    "label:ara_x_preferred_longname":[
+        "مِـنْـطَـقَـة مَـكَّـة الـمُـكَـرَّمَـة"
     ],
-    "label:ara_x_placetype_preferred":[
-        "\u0645\u0646\u0637\u0642\u0629 \u0625\u062f\u0627\u0631\u064a\u0629"
-    ],
-    "label:eng_x_placetype_longname":[
-        "Makkah Region"
-    ],
-    "label:eng_x_placetype_preferred":[
-        "region"
+    "label:ara_x_preferred_placetype":[
+        "مقاطعة"
     ],
     "label:eng_x_preferred_longname":[
         "Makkah Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":21.939103,
     "lbl:longitude":41.689276,

--- a/data/856/768/57/85676857.geojson
+++ b/data/856/768/57/85676857.geojson
@@ -5,16 +5,19 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.253268,
-    "geom:area_square_m":140825105193.074951,
+    "geom:area_square_m":140825105193.070984,
     "geom:bbox":"38.643749237,18.461194992,43.8291123316,23.6948880024",
     "geom:latitude":21.628768,
     "geom:longitude":41.257286,
     "iso:country":"SA",
+    "label:ara_latn_x_preferred_placetype":[
+        "muhafazah"
+    ],
     "label:ara_x_preferred_longname":[
-        "مِـنْـطَـقَـة مَـكَّـة الـمُـكَـرَّمَـة"
+        "\u0645\u0650\u0640\u0646\u0652\u0640\u0637\u064e\u0640\u0642\u064e\u0640\u0629 \u0645\u064e\u0640\u0643\u064e\u0651\u0640\u0629 \u0627\u0644\u0640\u0645\u064f\u0640\u0643\u064e\u0640\u0631\u064e\u0651\u0645\u064e\u0640\u0629"
     ],
     "label:ara_x_preferred_placetype":[
-        "مقاطعة"
+        "\u0645\u0642\u0627\u0637\u0639\u0629"
     ],
     "label:eng_x_preferred_longname":[
         "Makkah Region"
@@ -346,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814823,
+    "wof:lastmodified":1560448385,
     "wof:name":"Makkah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes the Saudi Arabia portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640.

- Updated existing `label` properties
- Adds localized Arabic longname and placetype labels, as well as Arabic (Latin) placetype

No PIP work required. Can merge once approved.