### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/112/606/185/9/1126061859.geojson
+++ b/data/112/606/185/9/1126061859.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126061859,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"An Nafal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/185/9/1126061859.geojson
+++ b/data/112/606/185/9/1126061859.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0641\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "An Nafal"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126061859,
-    "wof:lastmodified":1534379459,
-    "wof:name":"\u0627\u0644\u0646\u0641\u0644",
+    "wof:lastmodified":1601068393,
+    "wof:name":"An Nafal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/606/963/3/1126069633.geojson
+++ b/data/112/606/963/3/1126069633.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0645\u0643\u0629",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676857,
         102191569,
         85632253,
-        1108720727
+        1108720727,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126069633,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ajyad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/963/3/1126069633.geojson
+++ b/data/112/606/963/3/1126069633.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u062c\u064a\u0627\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Ajyad"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126069633,
-    "wof:lastmodified":1534379459,
-    "wof:name":"\u0627\u062c\u064a\u0627\u062f",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ajyad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/608/962/7/1126089627.geojson
+++ b/data/112/608/962/7/1126089627.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126089627,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Ar Rahmaniya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/608/962/7/1126089627.geojson
+++ b/data/112/608/962/7/1126089627.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u062d\u0645\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ar Rahmaniya"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126089627,
-    "wof:lastmodified":1534379459,
-    "wof:name":"\u0627\u0644\u0631\u062d\u0645\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Ar Rahmaniya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/609/816/5/1126098165.geojson
+++ b/data/112/609/816/5/1126098165.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u0632\u062f\u0647\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Izdihar"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126098165,
-    "wof:lastmodified":1534379459,
-    "wof:name":"\u0627\u0644\u0627\u0632\u062f\u0647\u0627\u0631",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Izdihar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/609/816/5/1126098165.geojson
+++ b/data/112/609/816/5/1126098165.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126098165,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Izdihar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/610/544/5/1126105445.geojson
+++ b/data/112/610/544/5/1126105445.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126105445,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ghirnatah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/610/544/5/1126105445.geojson
+++ b/data/112/610/544/5/1126105445.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u063a\u0631\u0646\u0627\u0637\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ghirnatah"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126105445,
-    "wof:lastmodified":1566638481,
-    "wof:name":"\u063a\u0631\u0646\u0627\u0637\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ghirnatah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/610/555/9/1126105559.geojson
+++ b/data/112/610/555/9/1126105559.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u064a\u0631\u0645\u0648\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Al Yarmouk"
+    ],
     "qs_pg:aaroncc":"SA",
     "qs_pg:gn_country":"SA",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126105559,
-    "wof:lastmodified":1534379458,
-    "wof:name":"\u0627\u0644\u064a\u0631\u0645\u0648\u0643",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Yarmouk",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/112/610/555/9/1126105559.geojson
+++ b/data/112/610/555/9/1126105559.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0627\u0644\u0631\u064a\u0627\u0636",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126105559,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Yarmouk",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/136/102/608/3/1361026083.geojson
+++ b/data/136/102/608/3/1361026083.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0631\u0627\u064a\u0639"
+    ],
+    "name:eng_x_preferred":[
+        "Al Cheraia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1361026083,
-    "wof:lastmodified":1566638435,
-    "wof:name":"\u0627\u0644\u0634\u0631\u0627\u064a\u0639",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Cheraia",
     "wof:parent_id":1108720727,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/136/102/608/3/1361026083.geojson
+++ b/data/136/102/608/3/1361026083.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":1938342,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676857,
         102191569,
         85632253,
+        1108720727,
         421190277,
-        1108720727
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1361026083,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Cheraia",
     "wof:parent_id":1108720727,
     "wof:placetype":"neighbourhood",

--- a/data/136/102/609/5/1361026095.geojson
+++ b/data/136/102/609/5/1361026095.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u064a\u0646\u0628\u0639 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Yanbu Industrial"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1361026095,
-    "wof:lastmodified":1566638438,
-    "wof:name":"\u064a\u0646\u0628\u0639 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Yanbu Industrial",
     "wof:parent_id":1108720795,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/136/102/609/5/1361026095.geojson
+++ b/data/136/102/609/5/1361026095.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":1938900,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676825,
         102191569,
         85632253,
+        1108720795,
         421190285,
-        1108720795
+        85676825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1361026095,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Yanbu Industrial",
     "wof:parent_id":1108720795,
     "wof:placetype":"neighbourhood",

--- a/data/421/169/909/421169909.geojson
+++ b/data/421/169/909/421169909.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062b\u0642\u0628\u0647 3"
+    ],
+    "name:eng_x_preferred":[
+        "Al-Thuqbah 3"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421169909,
-    "wof:lastmodified":1566638461,
-    "wof:name":"\u0627\u0644\u062b\u0642\u0628\u0647 3",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al-Thuqbah 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/169/909/421169909.geojson
+++ b/data/421/169/909/421169909.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":55948380,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676819,
         102191569,
         85632253,
-        1108720599
+        1108720599,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421169909,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al-Thuqbah 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/172/097/421172097.geojson
+++ b/data/421/172/097/421172097.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0644\u0639\u0647 \u0627\u0644\u0636\u0628\u064a\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Al Dhabia Castle"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172097,
-    "wof:lastmodified":1566638464,
-    "wof:name":"\u0642\u0644\u0639\u0647 \u0627\u0644\u0636\u0628\u064a\u0647",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Al Dhabia Castle",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/172/097/421172097.geojson
+++ b/data/421/172/097/421172097.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676819,
-        1108720541
+        1108720541,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172097,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Dhabia Castle",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",

--- a/data/421/172/099/421172099.geojson
+++ b/data/421/172/099/421172099.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"40.3201955,21.077619,40.3201955,21.077619",
+    "geom:bbox":"40.320195,21.077619,40.320195,21.077619",
     "geom:latitude":21.077619,
     "geom:longitude":40.320195,
     "iso:country":"SA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720639
+        1108720639,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459008920,
-    "wof:geomhash":"d2b667cf41a5a3a9f1feb759551dccd4",
+    "wof:geomhash":"32f2a81c0369b9dc2449b5ecbb29ec50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172099,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shifa",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    40.3201955,
+    40.320195,
     21.077619,
-    40.3201955,
+    40.320195,
     21.077619
 ],
-  "geometry": {"coordinates":[40.3201955,21.077619],"type":"Point"}
+  "geometry": {"coordinates":[40.320195,21.077619],"type":"Point"}
 }

--- a/data/421/172/099/421172099.geojson
+++ b/data/421/172/099/421172099.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0641\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shifa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172099,
-    "wof:lastmodified":1566638464,
-    "wof:name":"\u0627\u0644\u0634\u0641\u0627\u0621",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shifa",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/172/713/421172713.geojson
+++ b/data/421/172/713/421172713.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":55948688,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676819,
         102191569,
         85632253,
-        1108720599
+        1108720599,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172713,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khobar West 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/172/713/421172713.geojson
+++ b/data/421/172/713/421172713.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0628\u0631 \u0627\u0644\u063a\u0631\u0628\u064a\u0629 2"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khobar West 2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172713,
-    "wof:lastmodified":1566638465,
-    "wof:name":"\u0627\u0644\u062e\u0628\u0631 \u0627\u0644\u063a\u0631\u0628\u064a\u0629 2",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khobar West 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/174/907/421174907.geojson
+++ b/data/421/174/907/421174907.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0635\u062d\u064a\u0641\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "As Sahifa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421174907,
-    "wof:lastmodified":1566638463,
-    "wof:name":"\u0627\u0644\u0635\u062d\u064a\u0641\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"As Sahifa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/174/907/421174907.geojson
+++ b/data/421/174/907/421174907.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"39.192663,21.4853305,39.192663,21.4853305",
+    "geom:bbox":"39.192663,21.48533,39.192663,21.48533",
     "geom:latitude":21.48533,
     "geom:longitude":39.192663,
     "iso:country":"SA",
@@ -42,10 +42,10 @@
     "qs:woe_id":22726097,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676857,
         102191569,
         85632253,
-        1108720715
+        1108720715,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,7 +54,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009048,
-    "wof:geomhash":"c78214ab46c22e2b8d7f06d96af74cda",
+    "wof:geomhash":"61dc60b236319b3437ad91c8e48c77dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421174907,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"As Sahifa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     39.192663,
-    21.4853305,
+    21.48533,
     39.192663,
-    21.4853305
+    21.48533
 ],
-  "geometry": {"coordinates":[39.192663,21.4853305],"type":"Point"}
+  "geometry": {"coordinates":[39.192663,21.48533],"type":"Point"}
 }

--- a/data/421/177/055/421177055.geojson
+++ b/data/421/177/055/421177055.geojson
@@ -17,10 +17,14 @@
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:ara_x_preferred":[
-        "\u015eiy\u0101\u1e29"
+        "\u0635\u064a\u0627\u062d"
     ],
     "name:ara_x_variant":[
-        "\u0635\u064a\u0627\u062d"
+        "\u0635\u064a\u0627\u062d",
+        "\u015eiy\u0101\u1e29"
+    ],
+    "name:eng_x_preferred":[
+        "Siyah"
     ],
     "qs:gn_country":"SA",
     "qs:gn_fcode":"PPLX",
@@ -67,8 +71,8 @@
         }
     ],
     "wof:id":421177055,
-    "wof:lastmodified":1566638471,
-    "wof:name":"\u0635\u064a\u0627\u062d",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Siyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/177/055/421177055.geojson
+++ b/data/421/177/055/421177055.geojson
@@ -19,10 +19,6 @@
     "name:ara_x_preferred":[
         "\u0635\u064a\u0627\u062d"
     ],
-    "name:ara_x_variant":[
-        "\u0635\u064a\u0627\u062d",
-        "\u015eiy\u0101\u1e29"
-    ],
     "name:eng_x_preferred":[
         "Siyah"
     ],
@@ -46,10 +42,10 @@
     "qs:woe_id":22725958,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -71,7 +67,7 @@
         }
     ],
     "wof:id":421177055,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423092,
     "wof:name":"Siyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/177/375/421177375.geojson
+++ b/data/421/177/375/421177375.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":22725931,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421177375,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"An Namudhajiyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/177/375/421177375.geojson
+++ b/data/421/177/375/421177375.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0645\u0648\u0630\u062c\u064a\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "An Namudhajiyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421177375,
-    "wof:lastmodified":1566638471,
-    "wof:name":"\u0627\u0644\u0646\u0645\u0648\u0630\u062c\u064a\u0647",
+    "wof:lastmodified":1601068393,
+    "wof:name":"An Namudhajiyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/183/343/421183343.geojson
+++ b/data/421/183/343/421183343.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720715
+        1108720715,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183343,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Durrat Al Arous",
     "wof:parent_id":1108720715,
     "wof:placetype":"locality",

--- a/data/421/183/343/421183343.geojson
+++ b/data/421/183/343/421183343.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u0631\u0647 \u0627\u0644\u0639\u0631\u0648\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Durrat Al Arous"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183343,
-    "wof:lastmodified":1566638471,
-    "wof:name":"\u062f\u0631\u0647 \u0627\u0644\u0639\u0631\u0648\u0633",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Durrat Al Arous",
     "wof:parent_id":1108720715,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/184/249/421184249.geojson
+++ b/data/421/184/249/421184249.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.188293,26.2901705,50.188293,26.2901705",
+    "geom:bbox":"50.188293,26.29017,50.188293,26.29017",
     "geom:latitude":26.29017,
     "geom:longitude":50.188293,
     "iso:country":"SA",
@@ -42,10 +42,10 @@
     "qs:woe_id":55948786,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676819,
         102191569,
         85632253,
-        1108720599
+        1108720599,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,7 +54,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009405,
-    "wof:geomhash":"71b0913640de3f832e98ee005207b42c",
+    "wof:geomhash":"733c93e2f3ccce058ef9cbb5ffa609ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184249,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Basateen 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     50.188293,
-    26.2901705,
+    26.29017,
     50.188293,
-    26.2901705
+    26.29017
 ],
-  "geometry": {"coordinates":[50.188293,26.2901705],"type":"Point"}
+  "geometry": {"coordinates":[50.188293,26.29017],"type":"Point"}
 }

--- a/data/421/184/249/421184249.geojson
+++ b/data/421/184/249/421184249.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0633\u0627\u062a\u064a\u0646 2"
+    ],
+    "name:eng_x_preferred":[
+        "Al Basateen 2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184249,
-    "wof:lastmodified":1566638471,
-    "wof:name":"\u0627\u0644\u0628\u0633\u0627\u062a\u064a\u0646 2",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Basateen 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/184/515/421184515.geojson
+++ b/data/421/184/515/421184515.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":421184515,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Anoud",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/515/421184515.geojson
+++ b/data/421/184/515/421184515.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0646\u0648\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Al Anoud"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":421184515,
-    "wof:lastmodified":1566638471,
-    "wof:name":"\u0627\u0644\u0639\u0646\u0648\u062f",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Anoud",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/185/119/421185119.geojson
+++ b/data/421/185/119/421185119.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":22726000,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185119,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Salam",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/119/421185119.geojson
+++ b/data/421/185/119/421185119.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0644\u0627\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Al Salam"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185119,
-    "wof:lastmodified":1566638472,
-    "wof:name":"\u0627\u0644\u0633\u0644\u0627\u0645",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Salam",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/185/149/421185149.geojson
+++ b/data/421/185/149/421185149.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0642\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "An Naqrah"
+    ],
     "qs:gn_country":"SA",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":395015,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421185149,
-    "wof:lastmodified":1566638473,
-    "wof:name":"\u0627\u0644\u0646\u0642\u0631\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"An Naqrah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/185/149/421185149.geojson
+++ b/data/421/185/149/421185149.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":1938180,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676831,
         102191569,
         85632253,
-        1108720703
+        1108720703,
+        85676831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421185149,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"An Naqrah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/589/421188589.geojson
+++ b/data/421/188/589/421188589.geojson
@@ -19,6 +19,12 @@
     "name:ara_x_preferred":[
         "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646"
     ],
+    "name:ara_x_variant":[
+        "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Salahuddin"
+    ],
     "name:und_x_variant":[
         "\u015eal\u0101\u1e29 ad D\u012bn"
     ],
@@ -67,8 +73,8 @@
         }
     ],
     "wof:id":421188589,
-    "wof:lastmodified":1566638464,
-    "wof:name":"\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Salahuddin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/188/589/421188589.geojson
+++ b/data/421/188/589/421188589.geojson
@@ -19,9 +19,6 @@
     "name:ara_x_preferred":[
         "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646"
     ],
-    "name:ara_x_variant":[
-        "\u0635\u0644\u0627\u062d \u0627\u0644\u062f\u064a\u0646"
-    ],
     "name:eng_x_preferred":[
         "Salahuddin"
     ],
@@ -48,10 +45,10 @@
     "qs:woe_id":22725969,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676813,
         102191569,
         85632253,
-        1108720657
+        1108720657,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -73,7 +70,7 @@
         }
     ],
     "wof:id":421188589,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Salahuddin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/189/291/421189291.geojson
+++ b/data/421/189/291/421189291.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":26.234302,
     "geom:longitude":49.978823,
     "iso:country":"SA",
+    "label:eng_x_preferred_longname":[
+        "Dammam 2nd Industrial City"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:bbox":"49.958823,26.214302,49.998823,26.254302",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0645\u0627\u0645 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 \u0627\u0644\u062b\u0627\u0646\u064a\u0629"
     ],
     "name:eng_x_preferred":[
+        "Dammam 2nd Industrial"
+    ],
+    "name:eng_x_variant":[
         "Dammam 2nd Industrial City"
     ],
     "qs:gn_country":null,
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421189291,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Dammam 2nd Industrial City",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Dammam 2nd Industrial",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/189/291/421189291.geojson
+++ b/data/421/189/291/421189291.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":26.234302,
     "geom:longitude":49.978823,
     "iso:country":"SA",
-    "label:eng_x_preferred_longname":[
-        "Dammam 2nd Industrial City"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "city"
-    ],
     "lbl:bbox":"49.958823,26.214302,49.998823,26.254302",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -27,9 +21,6 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0645\u0627\u0645 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 \u0627\u0644\u062b\u0627\u0646\u064a\u0629"
     ],
     "name:eng_x_preferred":[
-        "Dammam 2nd Industrial"
-    ],
-    "name:eng_x_variant":[
         "Dammam 2nd Industrial City"
     ],
     "qs:gn_country":null,
@@ -54,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676819,
-        1108720541
+        1108720541,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,8 +66,8 @@
         }
     ],
     "wof:id":421189291,
-    "wof:lastmodified":1601337573,
-    "wof:name":"Dammam 2nd Industrial",
+    "wof:lastmodified":1601423088,
+    "wof:name":"Dammam 2nd Industrial City",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/189/291/421189291.geojson
+++ b/data/421/189/291/421189291.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0645\u0627\u0645 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 \u0627\u0644\u062b\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Dammam 2nd Industrial City"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189291,
-    "wof:lastmodified":1566638464,
-    "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0645\u0627\u0645 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 \u0627\u0644\u062b\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Dammam 2nd Industrial City",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/275/421190275.geojson
+++ b/data/421/190/275/421190275.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"47.1534915,24.004991,47.1534915,24.004991",
+    "geom:bbox":"47.153492,24.004991,47.153492,24.004991",
     "geom:latitude":24.004991,
     "geom:longitude":47.153492,
     "iso:country":"SA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676813,
-        1108720595
+        1108720595,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009652,
-    "wof:geomhash":"4c3c5408b22c86f5cfc990c201eb0f04",
+    "wof:geomhash":"414827b2e99beb0a29f7fce1375b8910",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190275,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ad Dilam",
     "wof:parent_id":1108720595,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    47.1534915,
+    47.153492,
     24.004991,
-    47.1534915,
+    47.153492,
     24.004991
 ],
-  "geometry": {"coordinates":[47.1534915,24.004991],"type":"Point"}
+  "geometry": {"coordinates":[47.153492,24.004991],"type":"Point"}
 }

--- a/data/421/190/275/421190275.geojson
+++ b/data/421/190/275/421190275.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062f\u0644\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Ad Dilam"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190275,
-    "wof:lastmodified":1566638466,
-    "wof:name":"\u0627\u0644\u062f\u0644\u0645",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Ad Dilam",
     "wof:parent_id":1108720595,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/277/421190277.geojson
+++ b/data/421/190/277/421190277.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720727
+        1108720727,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421190277,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Cheraia",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",

--- a/data/421/190/277/421190277.geojson
+++ b/data/421/190/277/421190277.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0631\u0627\u064a\u0639"
+    ],
+    "name:eng_x_preferred":[
+        "Al Cheraia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421190277,
-    "wof:lastmodified":1548452896,
-    "wof:name":"\u0627\u0644\u0634\u0631\u0627\u064a\u0639",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Cheraia",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/279/421190279.geojson
+++ b/data/421/190/279/421190279.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676813,
-        1108720667
+        1108720667,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190279,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423087,
     "wof:name":"Az Zulfi",
     "wof:parent_id":1108720667,
     "wof:placetype":"locality",

--- a/data/421/190/279/421190279.geojson
+++ b/data/421/190/279/421190279.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0632\u0644\u0641\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Az Zulfi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190279,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0627\u0644\u0632\u0644\u0641\u064a",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Az Zulfi",
     "wof:parent_id":1108720667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/283/421190283.geojson
+++ b/data/421/190/283/421190283.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u062a\u0646\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Tanura"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190283,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0631\u0627\u0633 \u062a\u0646\u0648\u0631\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Tanura",
     "wof:parent_id":1108720745,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/283/421190283.geojson
+++ b/data/421/190/283/421190283.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.0537965,26.715713,50.0537965,26.715713",
+    "geom:bbox":"50.053796,26.715713,50.053796,26.715713",
     "geom:latitude":26.715713,
     "geom:longitude":50.053796,
     "iso:country":"SA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676819,
-        1108720745
+        1108720745,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009653,
-    "wof:geomhash":"23d891cb0ab5917f7921f62fd455f710",
+    "wof:geomhash":"f2e276c14dfe5cccd9f54a2c1c466430",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190283,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Tanura",
     "wof:parent_id":1108720745,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    50.0537965,
+    50.053796,
     26.715713,
-    50.0537965,
+    50.053796,
     26.715713
 ],
-  "geometry": {"coordinates":[50.0537965,26.715713],"type":"Point"}
+  "geometry": {"coordinates":[50.053796,26.715713],"type":"Point"}
 }

--- a/data/421/190/285/421190285.geojson
+++ b/data/421/190/285/421190285.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676825,
-        1108720795
+        1108720795,
+        85676825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421190285,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Yanbu Industrial",
     "wof:parent_id":1108720795,
     "wof:placetype":"locality",

--- a/data/421/190/285/421190285.geojson
+++ b/data/421/190/285/421190285.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u064a\u0646\u0628\u0639 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Yanbu Industrial"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421190285,
-    "wof:lastmodified":1548452896,
-    "wof:name":"\u064a\u0646\u0628\u0639 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Yanbu Industrial",
     "wof:parent_id":1108720795,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/287/421190287.geojson
+++ b/data/421/190/287/421190287.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676813,
-        1108720621
+        1108720621,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190287,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khubayb Al Reem",
     "wof:parent_id":1108720621,
     "wof:placetype":"locality",

--- a/data/421/190/287/421190287.geojson
+++ b/data/421/190/287/421190287.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0628\u064a\u0628 \u0627\u0644\u0631\u064a\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Khubayb Al Reem"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190287,
-    "wof:lastmodified":1566638466,
-    "wof:name":"\u062e\u0628\u064a\u0628 \u0627\u0644\u0631\u064a\u0645",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khubayb Al Reem",
     "wof:parent_id":1108720621,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/291/421190291.geojson
+++ b/data/421/190/291/421190291.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"46.3881395,24.514162,46.3881395,24.514162",
+    "geom:bbox":"46.38814,24.514162,46.38814,24.514162",
     "geom:latitude":24.514162,
     "geom:longitude":46.38814,
     "iso:country":"SA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676813,
-        1108720695
+        1108720695,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009653,
-    "wof:geomhash":"e167d81747fbeb17f8d45ae7942ad064",
+    "wof:geomhash":"26c819c1d0a02ebe50426b57ab3b3be3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190291,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Moqbel Palaces",
     "wof:parent_id":1108720695,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    46.3881395,
+    46.38814,
     24.514162,
-    46.3881395,
+    46.38814,
     24.514162
 ],
-  "geometry": {"coordinates":[46.3881395,24.514162],"type":"Point"}
+  "geometry": {"coordinates":[46.38814,24.514162],"type":"Point"}
 }

--- a/data/421/190/291/421190291.geojson
+++ b/data/421/190/291/421190291.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0635\u0648\u0631 \u0645\u0642\u0628\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Moqbel Palaces"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190291,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0642\u0635\u0648\u0631 \u0645\u0642\u0628\u0644",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Al Moqbel Palaces",
     "wof:parent_id":1108720695,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/303/421190303.geojson
+++ b/data/421/190/303/421190303.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0630\u0646\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Muzannab"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190303,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0627\u0644\u0645\u0630\u0646\u0628",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Muzannab",
     "wof:parent_id":1108720617,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/303/421190303.geojson
+++ b/data/421/190/303/421190303.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676827,
-        1108720617
+        1108720617,
+        85676827
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190303,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Muzannab",
     "wof:parent_id":1108720617,
     "wof:placetype":"locality",

--- a/data/421/190/305/421190305.geojson
+++ b/data/421/190/305/421190305.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Muzahmiyya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190305,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0627\u0644\u0645\u0632\u0627\u062d\u0645\u064a\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Muzahmiyya",
     "wof:parent_id":1108720621,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/305/421190305.geojson
+++ b/data/421/190/305/421190305.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676813,
-        1108720621
+        1108720621,
+        85676813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190305,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Muzahmiyya",
     "wof:parent_id":1108720621,
     "wof:placetype":"locality",

--- a/data/421/190/311/421190311.geojson
+++ b/data/421/190/311/421190311.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720639
+        1108720639,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190311,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423087,
     "wof:name":"Arafah",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",

--- a/data/421/190/311/421190311.geojson
+++ b/data/421/190/311/421190311.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0631\u0641\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Arafah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190311,
-    "wof:lastmodified":1566638469,
-    "wof:name":"\u0639\u0631\u0641\u0647",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Arafah",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/313/421190313.geojson
+++ b/data/421/190/313/421190313.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720727
+        1108720727,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190313,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Bahrah",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",

--- a/data/421/190/313/421190313.geojson
+++ b/data/421/190/313/421190313.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u062d\u0631\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Bahrah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190313,
-    "wof:lastmodified":1566638468,
-    "wof:name":"\u0628\u062d\u0631\u0647",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bahrah",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/315/421190315.geojson
+++ b/data/421/190/315/421190315.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"42.5670425,16.883855,42.5670425,16.883855",
+    "geom:bbox":"42.567042,16.883855,42.567042,16.883855",
     "geom:latitude":16.883855,
     "geom:longitude":42.567042,
     "iso:country":"SA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676853,
-        1108720713
+        1108720713,
+        85676853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009654,
-    "wof:geomhash":"357f13765dfc82048f70dc0a27c896a5",
+    "wof:geomhash":"087034f6cfdd8852245a53d3abb6bc3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190315,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jazan",
     "wof:parent_id":1108720713,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    42.5670425,
+    42.567042,
     16.883855,
-    42.5670425,
+    42.567042,
     16.883855
 ],
-  "geometry": {"coordinates":[42.5670425,16.883855],"type":"Point"}
+  "geometry": {"coordinates":[42.567042,16.883855],"type":"Point"}
 }

--- a/data/421/190/315/421190315.geojson
+++ b/data/421/190/315/421190315.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0627\u0632\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Jazan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190315,
-    "wof:lastmodified":1566638467,
-    "wof:name":"\u062c\u0627\u0632\u0627\u0646",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jazan",
     "wof:parent_id":1108720713,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/190/327/421190327.geojson
+++ b/data/421/190/327/421190327.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676809,
-        1108720731
+        1108720731,
+        85676809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190327,
-    "wof:lastmodified":1601068387,
+    "wof:lastmodified":1601423082,
     "wof:name":"Aba Al Saud",
     "wof:parent_id":1108720731,
     "wof:placetype":"locality",

--- a/data/421/190/327/421190327.geojson
+++ b/data/421/190/327/421190327.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0627 \u0627\u0644\u0633\u0639\u0648\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Aba Al Saud"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190327,
-    "wof:lastmodified":1566638469,
-    "wof:name":"\u0627\u0628\u0627 \u0627\u0644\u0633\u0639\u0648\u062f",
+    "wof:lastmodified":1601068387,
+    "wof:name":"Aba Al Saud",
     "wof:parent_id":1108720731,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/196/503/421196503.geojson
+++ b/data/421/196/503/421196503.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Buraidah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009883,
-    "wof:geomhash":"5ed884781a6503e30000504715ba6bce",
+    "wof:geomhash":"a4195046db2ce09152f0b4ccd3bcffc3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421196503,
-    "wof:lastmodified":1476123548,
-    "wof:name":"\u0628\u0631\u064a\u062f\u0629",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Buraidah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/196/503/421196503.geojson
+++ b/data/421/196/503/421196503.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421196503,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Buraidah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/421/199/399/421199399.geojson
+++ b/data/421/199/399/421199399.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0628\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jubail"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459009988,
-    "wof:geomhash":"9aae0f3eed242d4f62300a2c18b51502",
+    "wof:geomhash":"84d274cee2f7abb6eb4ad1d588d0565a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421199399,
-    "wof:lastmodified":1476123547,
-    "wof:name":"\u0627\u0644\u062c\u0628\u064a\u0644",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jubail",
     "wof:parent_id":85676819,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/199/399/421199399.geojson
+++ b/data/421/199/399/421199399.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421199399,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jubail",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/421/202/653/421202653.geojson
+++ b/data/421/202/653/421202653.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0647\u062f\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hada "
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202653,
-    "wof:lastmodified":1566638462,
-    "wof:name":"\u0627\u0644\u0647\u062f\u0627",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Hada ",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/421/202/653/421202653.geojson
+++ b/data/421/202/653/421202653.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"40.261974,21.3635405,40.261974,21.3635405",
+    "geom:bbox":"40.261974,21.36354,40.261974,21.36354",
     "geom:latitude":21.36354,
     "geom:longitude":40.261974,
     "iso:country":"SA",
@@ -21,7 +21,7 @@
         "\u0627\u0644\u0647\u062f\u0627"
     ],
     "name:eng_x_preferred":[
-        "Al Hada "
+        "Al Hada"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676857,
-        1108720639
+        1108720639,
+        85676857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459010125,
-    "wof:geomhash":"a280b2041571ec4d5dcc2263e22359e9",
+    "wof:geomhash":"e72f8c7e7b96ec7ab05f52c48679d029",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,8 +66,8 @@
         }
     ],
     "wof:id":421202653,
-    "wof:lastmodified":1601068393,
-    "wof:name":"Al Hada ",
+    "wof:lastmodified":1601423084,
+    "wof:name":"Al Hada",
     "wof:parent_id":1108720639,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sa",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     40.261974,
-    21.3635405,
+    21.36354,
     40.261974,
-    21.3635405
+    21.36354
 ],
-  "geometry": {"coordinates":[40.261974,21.3635405],"type":"Point"}
+  "geometry": {"coordinates":[40.261974,21.36354],"type":"Point"}
 }

--- a/data/421/203/619/421203619.geojson
+++ b/data/421/203/619/421203619.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421203619,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423082,
     "wof:name":"Abha",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/421/203/619/421203619.geojson
+++ b/data/421/203/619/421203619.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0647\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Abha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"SA",
     "wof:created":1459010158,
-    "wof:geomhash":"b804c5031f2744fd47355ab75a6e56e5",
+    "wof:geomhash":"1f0cd01ab9d9159a6dc42496cd44f2a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421203619,
-    "wof:lastmodified":1476123547,
-    "wof:name":"\u0627\u0628\u0647\u0627",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Abha",
     "wof:parent_id":85676851,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-sa",

--- a/data/890/443/133/890443133.geojson
+++ b/data/890/443/133/890443133.geojson
@@ -35,10 +35,10 @@
     "qs:placetype":"Suburb",
     "qs:pop_sr":"0",
     "wof:belongsto":[
-        85676819,
         102191569,
         85632253,
-        1108720599
+        1108720599,
+        85676819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":890443133,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bandariyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/443/133/890443133.geojson
+++ b/data/890/443/133/890443133.geojson
@@ -17,6 +17,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0646\u062f\u0631\u064a\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bandariyah"
+    ],
     "qs:name":"\u0627\u0644\u0628\u0646\u062f\u0631\u064a\u0647",
     "qs:name_adm0":"\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629",
     "qs:name_adm1":"\u0627\u0644\u0634\u0631\u0642\u064a\u0629",
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":890443133,
-    "wof:lastmodified":1566638475,
-    "wof:name":"\u0627\u0644\u0628\u0646\u062f\u0631\u064a\u0647",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Bandariyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-sa",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.