### PR TITLE
WIP: Update megacities

### DIFF
--- a/data/421/166/941/421166941.geojson
+++ b/data/421/166/941/421166941.geojson
@@ -30,10 +30,10 @@
         "\u1218\u12f2\u1293"
     ],
     "name:ara_x_preferred":[
-        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629"
+        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629"
     ],
     "name:ara_x_variant":[
-        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0629"
+        "\u0627\u0644\u0645\u062f\u064a\u0646\u0629"
     ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0645\u0646\u0648\u0631\u0647"
@@ -533,6 +533,7 @@
     "wof:concordances":{
         "gn:id":109223,
         "gp:id":1937801,
+        "ne:id":1159149443,
         "qs_pg:id":122216,
         "wd:id":"Q35484",
         "wk:page":"Medina"
@@ -553,7 +554,7 @@
         }
     ],
     "wof:id":421166941,
-    "wof:lastmodified":1608675977,
+    "wof:lastmodified":1608677530,
     "wof:megacity":1,
     "wof:name":"Medina",
     "wof:parent_id":1108720605,

--- a/data/421/166/941/421166941.geojson
+++ b/data/421/166/941/421166941.geojson
@@ -553,7 +553,8 @@
         }
     ],
     "wof:id":421166941,
-    "wof:lastmodified":1607462740,
+    "wof:lastmodified":1608675977,
+    "wof:megacity":1,
     "wof:name":"Medina",
     "wof:parent_id":1108720605,
     "wof:placetype":"locality",

--- a/data/421/190/297/421190297.geojson
+++ b/data/421/190/297/421190297.geojson
@@ -180,10 +180,10 @@
         "\u062f\u0645\u0627\u0645"
     ],
     "name:pol_x_preferred":[
-        "Ad-Dammam"
+        "Dammam"
     ],
     "name:pol_x_variant":[
-        "Dammam"
+        "Ad-Dammam"
     ],
     "name:por_x_preferred":[
         "Dammam"
@@ -395,6 +395,7 @@
     "wof:concordances":{
         "gn:id":110336,
         "gp:id":1939574,
+        "ne:id":1159136389,
         "qs_pg:id":66772,
         "wd:id":"Q160320"
     },
@@ -417,7 +418,7 @@
         }
     ],
     "wof:id":421190297,
-    "wof:lastmodified":1608675973,
+    "wof:lastmodified":1608677520,
     "wof:megacity":1,
     "wof:name":"Dammam",
     "wof:parent_id":1108720541,

--- a/data/421/190/297/421190297.geojson
+++ b/data/421/190/297/421190297.geojson
@@ -417,7 +417,8 @@
         }
     ],
     "wof:id":421190297,
-    "wof:lastmodified":1607462740,
+    "wof:lastmodified":1608675973,
+    "wof:megacity":1,
     "wof:name":"Dammam",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",

--- a/data/421/200/923/421200923.geojson
+++ b/data/421/200/923/421200923.geojson
@@ -204,11 +204,11 @@
         "Jeddah"
     ],
     "name:ita_x_preferred":[
-        "Jedda"
+        "Gedda"
     ],
     "name:ita_x_variant":[
         "Jeddah",
-        "Gedda"
+        "Jedda"
     ],
     "name:jav_x_preferred":[
         "Jeddah"
@@ -367,13 +367,13 @@
         "Jeddah"
     ],
     "name:spa_x_preferred":[
-        "Jedda"
+        "Yeda"
     ],
     "name:spa_x_variant":[
         "Yida",
         "Yidda",
         "Jeddah",
-        "Yeda"
+        "Jedda"
     ],
     "name:sqi_x_preferred":[
         "Xheda"
@@ -388,10 +388,10 @@
         "Jeddah"
     ],
     "name:swe_x_preferred":[
-        "Jidda"
+        "Jeddah"
     ],
     "name:swe_x_variant":[
-        "Jeddah"
+        "Jidda"
     ],
     "name:szl_x_preferred":[
         "D\u017cudda"
@@ -589,6 +589,7 @@
     "wof:concordances":{
         "gn:id":105343,
         "gp:id":1939873,
+        "ne:id":1159151277,
         "qs_pg:id":900255,
         "wd:id":"Q374365",
         "wk:page":"Jeddah"
@@ -612,7 +613,7 @@
         }
     ],
     "wof:id":421200923,
-    "wof:lastmodified":1608675982,
+    "wof:lastmodified":1608677545,
     "wof:megacity":1,
     "wof:name":"Jeddah",
     "wof:parent_id":1108720715,

--- a/data/421/200/923/421200923.geojson
+++ b/data/421/200/923/421200923.geojson
@@ -612,7 +612,8 @@
         }
     ],
     "wof:id":421200923,
-    "wof:lastmodified":1587427680,
+    "wof:lastmodified":1608675982,
+    "wof:megacity":1,
     "wof:name":"Jeddah",
     "wof:parent_id":1108720715,
     "wof:placetype":"locality",

--- a/data/421/204/201/421204201.geojson
+++ b/data/421/204/201/421204201.geojson
@@ -489,10 +489,10 @@
         "Makka"
     ],
     "name:swe_x_preferred":[
-        "Mecka"
+        "Mekka"
     ],
     "name:swe_x_variant":[
-        "Mekka"
+        "Mecka"
     ],
     "name:szl_x_preferred":[
         "Mekka"
@@ -699,6 +699,7 @@
         "gn:id":104515,
         "gp:id":1939897,
         "loc:id":"n79032243",
+        "ne:id":1159151279,
         "qs_pg:id":238646,
         "wd:id":"Q5806",
         "wk:page":"Mecca"
@@ -719,7 +720,7 @@
         }
     ],
     "wof:id":421204201,
-    "wof:lastmodified":1608675982,
+    "wof:lastmodified":1608677545,
     "wof:megacity":1,
     "wof:name":"Mecca",
     "wof:parent_id":1108720727,

--- a/data/421/204/201/421204201.geojson
+++ b/data/421/204/201/421204201.geojson
@@ -719,7 +719,8 @@
         }
     ],
     "wof:id":421204201,
-    "wof:lastmodified":1607462741,
+    "wof:lastmodified":1608675982,
+    "wof:megacity":1,
     "wof:name":"Mecca",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",

--- a/data/421/204/501/421204501.geojson
+++ b/data/421/204/501/421204501.geojson
@@ -240,10 +240,10 @@
         "R\u00edad"
     ],
     "name:ita_x_preferred":[
-        "Riyad"
+        "Riad"
     ],
     "name:ita_x_variant":[
-        "Riad"
+        "Riyad"
     ],
     "name:jav_x_preferred":[
         "Riyadh"
@@ -653,6 +653,7 @@
     "wof:concordances":{
         "gn:id":108410,
         "gp:id":1939753,
+        "ne:id":1159151581,
         "qs_pg:id":241147,
         "wd:id":"Q3692",
         "wk:page":"Riyadh"
@@ -673,7 +674,7 @@
         }
     ],
     "wof:id":421204501,
-    "wof:lastmodified":1608675987,
+    "wof:lastmodified":1608677557,
     "wof:megacity":1,
     "wof:name":"Riyadh",
     "wof:parent_id":1108720657,

--- a/data/421/204/501/421204501.geojson
+++ b/data/421/204/501/421204501.geojson
@@ -673,7 +673,8 @@
         }
     ],
     "wof:id":421204501,
-    "wof:lastmodified":1607462739,
+    "wof:lastmodified":1608675987,
+    "wof:megacity":1,
     "wof:name":"Riyadh",
     "wof:parent_id":1108720657,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names
  - label centroids
  - megacity flags
  - geometries
- Updates parent geometries when necessary

To do:
- Update any parent geometries
- Ensure that all existing `wof:megacity` properties are on correct records