### PR TITLE
Update megacity records

### DIFF
--- a/data/421/166/941/421166941.geojson
+++ b/data/421/166/941/421166941.geojson
@@ -533,6 +533,7 @@
     "wof:concordances":{
         "gn:id":109223,
         "gp:id":1937801,
+        "ne:id":1159149443,
         "qs_pg:id":122216,
         "wd:id":"Q35484",
         "wk:page":"Medina"
@@ -553,7 +554,8 @@
         }
     ],
     "wof:id":421166941,
-    "wof:lastmodified":1607462740,
+    "wof:lastmodified":1608688170,
+    "wof:megacity":1,
     "wof:name":"Medina",
     "wof:parent_id":1108720605,
     "wof:placetype":"locality",

--- a/data/421/190/297/421190297.geojson
+++ b/data/421/190/297/421190297.geojson
@@ -395,6 +395,7 @@
     "wof:concordances":{
         "gn:id":110336,
         "gp:id":1939574,
+        "ne:id":1159136389,
         "qs_pg:id":66772,
         "wd:id":"Q160320"
     },
@@ -417,7 +418,8 @@
         }
     ],
     "wof:id":421190297,
-    "wof:lastmodified":1607462740,
+    "wof:lastmodified":1608688162,
+    "wof:megacity":1,
     "wof:name":"Dammam",
     "wof:parent_id":1108720541,
     "wof:placetype":"locality",

--- a/data/421/200/923/421200923.geojson
+++ b/data/421/200/923/421200923.geojson
@@ -589,6 +589,7 @@
     "wof:concordances":{
         "gn:id":105343,
         "gp:id":1939873,
+        "ne:id":1159151277,
         "qs_pg:id":900255,
         "wd:id":"Q374365",
         "wk:page":"Jeddah"
@@ -612,7 +613,8 @@
         }
     ],
     "wof:id":421200923,
-    "wof:lastmodified":1587427680,
+    "wof:lastmodified":1608688183,
+    "wof:megacity":1,
     "wof:name":"Jeddah",
     "wof:parent_id":1108720715,
     "wof:placetype":"locality",

--- a/data/421/204/201/421204201.geojson
+++ b/data/421/204/201/421204201.geojson
@@ -699,6 +699,7 @@
         "gn:id":104515,
         "gp:id":1939897,
         "loc:id":"n79032243",
+        "ne:id":1159151279,
         "qs_pg:id":238646,
         "wd:id":"Q5806",
         "wk:page":"Mecca"
@@ -719,7 +720,8 @@
         }
     ],
     "wof:id":421204201,
-    "wof:lastmodified":1607462741,
+    "wof:lastmodified":1608688183,
+    "wof:megacity":1,
     "wof:name":"Mecca",
     "wof:parent_id":1108720727,
     "wof:placetype":"locality",

--- a/data/421/204/501/421204501.geojson
+++ b/data/421/204/501/421204501.geojson
@@ -653,6 +653,7 @@
     "wof:concordances":{
         "gn:id":108410,
         "gp:id":1939753,
+        "ne:id":1159151581,
         "qs_pg:id":241147,
         "wd:id":"Q3692",
         "wk:page":"Riyadh"
@@ -673,7 +674,8 @@
         }
     ],
     "wof:id":421204501,
-    "wof:lastmodified":1607462739,
+    "wof:lastmodified":1608688192,
+    "wof:megacity":1,
     "wof:name":"Riyadh",
     "wof:parent_id":1108720657,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary