### PR TITLE
Update and add names to a handful of places in SA

### DIFF
--- a/data/122/655/469/7/1226554697.geojson
+++ b/data/122/655/469/7/1226554697.geojson
@@ -27,7 +27,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062e\u064a\u0628\u0631"
@@ -43,6 +43,9 @@
     ],
     "name:deu_x_preferred":[
         "Chaibar"
+    ],
+    "name:eng_x_preferred":[
+        "Khaybar"
     ],
     "name:fas_x_preferred":[
         "\u062e\u06cc\u0628\u0631"
@@ -102,8 +105,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676851,
-        1108720717
+        1108720717,
+        85676851
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":1226554697,
-    "wof:lastmodified":1566638571,
+    "wof:lastmodified":1674167623,
     "wof:name":"Khaybar",
     "wof:parent_id":1108720717,
     "wof:placetype":"locality",

--- a/data/130/982/198/3/1309821983.geojson
+++ b/data/130/982/198/3/1309821983.geojson
@@ -28,7 +28,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062e\u064a\u0628\u0631"
@@ -44,6 +44,9 @@
     ],
     "name:deu_x_preferred":[
         "Chaibar"
+    ],
+    "name:eng_x_preferred":[
+        "Khaybar"
     ],
     "name:fas_x_preferred":[
         "\u062e\u06cc\u0628\u0631"
@@ -103,8 +106,8 @@
     "wof:belongsto":[
         102191569,
         85632253,
-        85676851,
-        1108720681
+        1108720681,
+        85676851
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":1309821983,
-    "wof:lastmodified":1566638453,
+    "wof:lastmodified":1674167628,
     "wof:name":"Khaybar",
     "wof:parent_id":1108720681,
     "wof:placetype":"locality",

--- a/data/856/768/13/85676813.geojson
+++ b/data/856/768/13/85676813.geojson
@@ -330,8 +330,8 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636496656,
-    "wof:name":"Ar Riyad",
+    "wof:lastmodified":1674167632,
+    "wof:name":"Riyadh",
     "wof:parent_id":85632253,
     "wof:placetype":"region",
     "wof:population":6505509,


### PR DESCRIPTION
This PR adjusts the names/labels in the region record for Riyadh, and adds two `name:eng_x_preferred` properties to two distinct locality records for Khaybar.

No PIP work needed, can merge once approved.