### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/859/075/23/85907523.geojson
+++ b/data/859/075/23/85907523.geojson
@@ -11,8 +11,8 @@
     "geom:longitude":39.127051,
     "gn:id":"",
     "iso:country":"SA",
-    "lbl:latitude":21.606119,
-    "lbl:longitude":39.13221,
+    "lbl:latitude":21.619837,
+    "lbl:longitude":39.127051,
     "lbl:max_zoom":18.0,
     "mps:latitude":21.619837,
     "mps:longitude":39.127051,
@@ -62,13 +62,13 @@
         "quattroshapes",
         "mz"
     ],
-    "src:lbl_centroid":"yerbashapes",
+    "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
+        85676857,
         102191569,
         85632253,
         421200923,
-        1108720715,
-        85676857
+        1108720715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -96,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1627685903,
+    "wof:lastmodified":1694320549,
     "wof:name":"An Nahdah",
     "wof:parent_id":421200923,
     "wof:placetype":"neighbourhood",

--- a/data/859/329/47/85932947.geojson
+++ b/data/859/329/47/85932947.geojson
@@ -11,8 +11,8 @@
     "geom:longitude":50.090701,
     "gn:id":"",
     "iso:country":"SA",
-    "lbl:latitude":26.468349,
-    "lbl:longitude":50.081569,
+    "lbl:latitude":26.472069,
+    "lbl:longitude":50.090561,
     "lbl:max_zoom":18.0,
     "mps:latitude":26.472069,
     "mps:longitude":50.090561,
@@ -62,12 +62,12 @@
         "quattroshapes",
         "mz"
     ],
-    "src:lbl_centroid":"yerbashapes",
+    "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
+        85676819,
         102191569,
         85632253,
-        1108720541,
-        85676819
+        1108720541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -95,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1627685929,
+    "wof:lastmodified":1694320549,
     "wof:name":"Al Hamra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.