### PR TITLE
sa concordances, placetype local, and more

### DIFF
--- a/data/110/872/053/3/1108720533.geojson
+++ b/data/110/872/053/3/1108720533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.707614,
-    "geom:area_square_m":8304640101.730707,
+    "geom:area_square_m":8304639707.667048,
     "geom:bbox":"41.414528,17.486969,43.35326,19.203694",
     "geom:latitude":18.350749,
     "geom:longitude":42.288551,
@@ -226,9 +226,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123342,
-    "wof:geomhash":"693d106758179a2ab5f159023b3534cd",
+    "wof:geomhash":"f29142a9b66cb0581f1a066f7da7a905",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -238,7 +239,7 @@
         }
     ],
     "wof:id":1108720533,
-    "wof:lastmodified":1636496659,
+    "wof:lastmodified":1695886726,
     "wof:name":"Abha",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/053/5/1108720535.geojson
+++ b/data/110/872/053/5/1108720535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08079,
-    "geom:area_square_m":955500432.315196,
+    "geom:area_square_m":955500743.124969,
     "geom:bbox":"42.60564,16.825966,43.04322,17.160216",
     "geom:latitude":16.966495,
     "geom:longitude":42.828081,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.AA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123343,
-    "wof:geomhash":"90cf08d0bd39cfcd06dd4806d94e112e",
+    "wof:geomhash":"5fffd75c379a6bb10e99ae2937604cef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720535,
-    "wof:lastmodified":1627522740,
+    "wof:lastmodified":1695886444,
     "wof:name":"Abu Arish",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/053/7/1108720537.geojson
+++ b/data/110/872/053/7/1108720537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064489,
-    "geom:area_square_m":760852292.86393,
+    "geom:area_square_m":760852675.02148,
     "geom:bbox":"42.980159,17.189525,43.3365,17.597364",
     "geom:latitude":17.418739,
     "geom:longitude":43.149703,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123344,
-    "wof:geomhash":"8b0ecd93dc9296c9ba18c3285f54eb95",
+    "wof:geomhash":"c0ba26e95e2c31393c76a5cd04b60b4e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720537,
-    "wof:lastmodified":1627522740,
+    "wof:lastmodified":1695886445,
     "wof:name":"Ad-Dair",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/054/1/1108720541.geojson
+++ b/data/110/872/054/1/1108720541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130916,
-    "geom:area_square_m":1449687031.380691,
+    "geom:area_square_m":1449686787.169088,
     "geom:bbox":"49.58917,26.197232,50.228006,26.675038",
     "geom:latitude":26.423097,
     "geom:longitude":49.873994,
@@ -85,12 +85,13 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123345,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"a5021caf7c580d59138aa6a15345b6f9",
+    "wof:geomhash":"a526a2b8769f32e5f8dbf51164fe6927",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108720541,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886455,
     "wof:name":"Ad-Dammam",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/054/3/1108720543.geojson
+++ b/data/110/872/054/3/1108720543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116357,
-    "geom:area_square_m":1305253058.57699,
+    "geom:area_square_m":1305252521.557797,
     "geom:bbox":"46.078949,24.696795,46.63132,25.040032",
     "geom:latitude":24.8788,
     "geom:longitude":46.372896,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123346,
-    "wof:geomhash":"5db30dc1c7d02350c26972ecf2db98ad",
+    "wof:geomhash":"9fe224eaa99bd00dbbe1a71836f5ff84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720543,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886455,
     "wof:name":"Ad-Diriyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/5/1108720545.geojson
+++ b/data/110/872/054/5/1108720545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.484945,
-    "geom:area_square_m":27927470122.968105,
+    "geom:area_square_m":27927470415.812412,
     "geom:bbox":"43.104831,23.673166,45.210713,25.598236",
     "geom:latitude":24.64339,
     "geom:longitude":44.157791,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.DW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123347,
-    "wof:geomhash":"c106d902856764d550e85d995b7695b1",
+    "wof:geomhash":"b0e3cf696547ece04bbe482283168ee8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720545,
-    "wof:lastmodified":1627522740,
+    "wof:lastmodified":1695886445,
     "wof:name":"Ad-Duwadimi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/7/1108720547.geojson
+++ b/data/110/872/054/7/1108720547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.246496,
-    "geom:area_square_m":25434354630.529942,
+    "geom:area_square_m":25434354853.908916,
     "geom:bbox":"41.681567,22.418172,43.680469,24.732147",
     "geom:latitude":23.700691,
     "geom:longitude":42.830264,
@@ -127,9 +127,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123348,
-    "wof:geomhash":"86bd8c6bba946550dbe43bc649b86734",
+    "wof:geomhash":"7f3aac2ff4ddb148abbba91062e26310",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108720547,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886445,
     "wof:name":"Afif",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/054/9/1108720549.geojson
+++ b/data/110/872/054/9/1108720549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072193,
-    "geom:area_square_m":854773810.232852,
+    "geom:area_square_m":854773800.638653,
     "geom:bbox":"42.646821,16.598205,43.058302,16.903591",
     "geom:latitude":16.75787,
     "geom:longitude":42.852127,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123350,
-    "wof:geomhash":"a261ed88cd01b029ef9793b2cadb9a2d",
+    "wof:geomhash":"7b62b366ff17976d17a12bb390ba44a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720549,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Ahad al-Musarihah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/055/1/1108720551.geojson
+++ b/data/110/872/055/1/1108720551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254405,
-    "geom:area_square_m":2985432954.479954,
+    "geom:area_square_m":2985432732.857008,
     "geom:bbox":"42.692574,18.0089,43.714935,18.867801",
     "geom:latitude":18.37064,
     "geom:longitude":43.24937,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123351,
-    "wof:geomhash":"4c9f77298f242253efb2ed5f9195839f",
+    "wof:geomhash":"2be084b50a23a31740b4ddfc66b52f45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720551,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Ahd Rifaydah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/055/3/1108720553.geojson
+++ b/data/110/872/055/3/1108720553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.476124,
-    "geom:area_square_m":51284436429.703049,
+    "geom:area_square_m":51284434755.27536,
     "geom:bbox":"45.363045,20.929498,48.237069,23.238347",
     "geom:latitude":22.085392,
     "geom:longitude":46.850654,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.AJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123352,
-    "wof:geomhash":"b0408953a8f481243acc9bdb05eccfe4",
+    "wof:geomhash":"e990423cbfe6a431af21383bbebf9e5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720553,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886450,
     "wof:name":"Al-Aflaj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/055/5/1108720555.geojson
+++ b/data/110/872/055/5/1108720555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":36.094469,
-    "geom:area_square_m":413423161934.793457,
+    "geom:area_square_m":413423168413.036499,
     "geom:bbox":"47.526772,19.000336,55.6667,26.601031",
     "geom:latitude":22.079082,
     "geom:longitude":50.943091,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123353,
-    "wof:geomhash":"91872895ebbce3554d151424e55c5721",
+    "wof:geomhash":"a656bc904bb3fa8190f79f838cacd653",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108720555,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886450,
     "wof:name":"Al-Ahsa",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/055/9/1108720559.geojson
+++ b/data/110/872/055/9/1108720559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318158,
-    "geom:area_square_m":3686764293.538769,
+    "geom:area_square_m":3686764700.801573,
     "geom:bbox":"41.406152,20.019027,42.128673,20.792224",
     "geom:latitude":20.423782,
     "geom:longitude":41.692894,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123355,
-    "wof:geomhash":"377548b75081427db2af1b5571b1156c",
+    "wof:geomhash":"2d19f4985b1eaafa6534c539a340014f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720559,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Al-Aqiq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/056/1/1108720561.geojson
+++ b/data/110/872/056/1/1108720561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057934,
-    "geom:area_square_m":684931486.382269,
+    "geom:area_square_m":684931649.836902,
     "geom:bbox":"42.949637,16.837925,43.242611,17.21648",
     "geom:latitude":17.036578,
     "geom:longitude":43.083152,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123356,
-    "wof:geomhash":"c0890fb77044df01ee6e6cfb59ef4751",
+    "wof:geomhash":"a05862030674b13cdcfe241307fdad84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720561,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886451,
     "wof:name":"Al-Aridah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/056/3/1108720563.geojson
+++ b/data/110/872/056/3/1108720563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302085,
-    "geom:area_square_m":3329810002.358619,
+    "geom:area_square_m":3329809724.500468,
     "geom:bbox":"43.768022,26.559482,44.823401,27.340981",
     "geom:latitude":26.945356,
     "geom:longitude":44.165485,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123357,
-    "wof:geomhash":"1077de27e39828a805e5b2f1ba470504",
+    "wof:geomhash":"e7920e45170612d24dc6c76d756deaee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720563,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Al-Asyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/5/1108720565.geojson
+++ b/data/110/872/056/5/1108720565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115474,
-    "geom:area_square_m":1285608410.19654,
+    "geom:area_square_m":1285608768.84748,
     "geom:bbox":"43.626646,25.472136,43.939548,26.162736",
     "geom:latitude":25.792338,
     "geom:longitude":43.777556,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123358,
-    "wof:geomhash":"3daa67bfb845a61ee52a0df9c33f8b98",
+    "wof:geomhash":"17d4af6470e84e8ed8fb28bbf9407da0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720565,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Al-Badai",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/056/7/1108720567.geojson
+++ b/data/110/872/056/7/1108720567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025633,
-    "geom:area_square_m":297787162.419054,
+    "geom:area_square_m":297786895.818184,
     "geom:bbox":"41.369243,19.890736,41.57733,20.155841",
     "geom:latitude":20.028252,
     "geom:longitude":41.466081,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123359,
-    "wof:geomhash":"4d955c9f9fad4bafe16918378b5767ba",
+    "wof:geomhash":"9f287fcfe756cb1f733ea4f9659267b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720567,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Al-Bahah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/056/9/1108720569.geojson
+++ b/data/110/872/056/9/1108720569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342338,
-    "geom:area_square_m":3789828077.165712,
+    "geom:area_square_m":3789828576.668061,
     "geom:bbox":"42.601537,26.063883,43.770759,26.760025",
     "geom:latitude":26.454127,
     "geom:longitude":43.197591,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123360,
-    "wof:geomhash":"fcd1801d83151a8906293d1162fa3d8f",
+    "wof:geomhash":"4ba76565ffcc4249a34fc395fdabadac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720569,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886446,
     "wof:name":"Al-Bukayriyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/057/1/1108720571.geojson
+++ b/data/110/872/057/1/1108720571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16264,
-    "geom:area_square_m":1807760038.702727,
+    "geom:area_square_m":1807760356.495803,
     "geom:bbox":"44.611189,25.686248,45.177001,26.200479",
     "geom:latitude":25.985722,
     "geom:longitude":44.887238,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123361,
-    "wof:geomhash":"c5da4b7e5380d21a1b5e541ccc32a789",
+    "wof:geomhash":"ee5f2cd8d5a10951f21772eb73d6dfca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108720571,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Ghat",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/3/1108720573.geojson
+++ b/data/110/872/057/3/1108720573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.42729,
-    "geom:area_square_m":26933247652.739384,
+    "geom:area_square_m":26933248272.808632,
     "geom:bbox":"39.904144,25.258007,42.011287,27.271543",
     "geom:latitude":26.18372,
     "geom:longitude":40.937838,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HA.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123362,
-    "wof:geomhash":"b4c443ecf128f7dc2e0b0a626d33deaf",
+    "wof:geomhash":"52112cb769e4582495c6407f7c5598bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720573,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Ghazalah",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/057/7/1108720577.geojson
+++ b/data/110/872/057/7/1108720577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.455016,
-    "geom:area_square_m":5161308686.819911,
+    "geom:area_square_m":5161308421.731634,
     "geom:bbox":"45.620225,22.907118,46.767408,23.907489",
     "geom:latitude":23.458126,
     "geom:longitude":46.180675,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123363,
-    "wof:geomhash":"bdd1b76f76fd41204c4965d86d529da7",
+    "wof:geomhash":"c1d5c489224d03a8a066c92d0b22ea71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720577,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Hariq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/057/9/1108720579.geojson
+++ b/data/110/872/057/9/1108720579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030274,
-    "geom:area_square_m":358377446.481165,
+    "geom:area_square_m":358377153.672456,
     "geom:bbox":"43.04219,16.641694,43.266389,16.912443",
     "geom:latitude":16.792259,
     "geom:longitude":43.14997,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123364,
-    "wof:geomhash":"17d4c7fb1cedc1f22eb9250021eb4ce0",
+    "wof:geomhash":"ac0667993a1cbff63f5b69294dad43a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720579,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Harth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/058/1/1108720581.geojson
+++ b/data/110/872/058/1/1108720581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.206969,
-    "geom:area_square_m":24787072527.395809,
+    "geom:area_square_m":24787072368.946472,
     "geom:bbox":"39.849578,23.507845,42.133235,25.599428",
     "geom:latitude":24.724926,
     "geom:longitude":40.976379,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123365,
-    "wof:geomhash":"ef6e1e4ffebe36a78f15771def14d268",
+    "wof:geomhash":"5838d7a77e37f538effec1889c917828",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720581,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Hinakiyah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/058/3/1108720583.geojson
+++ b/data/110/872/058/3/1108720583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076188,
-    "geom:area_square_m":899073463.349854,
+    "geom:area_square_m":899073389.957291,
     "geom:bbox":"42.738275,17.15067,43.098192,17.576596",
     "geom:latitude":17.378103,
     "geom:longitude":42.941155,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.ID"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123367,
-    "wof:geomhash":"443e61978632f450d54d77dc4d0bd7f6",
+    "wof:geomhash":"0280531c33d4750db49a676fa96cf742",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720583,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886447,
     "wof:name":"Al-Idabi",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/058/5/1108720585.geojson
+++ b/data/110/872/058/5/1108720585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.572406,
-    "geom:area_square_m":6310682722.784537,
+    "geom:area_square_m":6310682599.834313,
     "geom:bbox":"48.919254,26.419536,49.878618,27.497269",
     "geom:latitude":26.923662,
     "geom:longitude":49.340544,
@@ -85,12 +85,13 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123368,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"e08172ce0fca9e77b044efce87bc04ff",
+    "wof:geomhash":"c85b968c9bd07f83160448644275a55b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108720585,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886456,
     "wof:name":"Al-Jubayl",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/058/7/1108720587.geojson
+++ b/data/110/872/058/7/1108720587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.551829,
-    "geom:area_square_m":6330613193.092813,
+    "geom:area_square_m":6330613195.917301,
     "geom:bbox":"39.207777,21.466688,40.608736,22.539113",
     "geom:latitude":21.909313,
     "geom:longitude":39.913104,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123369,
-    "wof:geomhash":"d839b0f9deb5506c34d8c0d0e6a79d71",
+    "wof:geomhash":"7aca0b41f4235a3c689ec2bd8fe41155",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720587,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886448,
     "wof:name":"Al-Jumum",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/058/9/1108720589.geojson
+++ b/data/110/872/058/9/1108720589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248304,
-    "geom:area_square_m":2838261922.744699,
+    "geom:area_square_m":2838261922.744429,
     "geom:bbox":"39.5170672574,22.0961007315,40.2350106449,22.7872715629",
     "geom:latitude":22.418842,
     "geom:longitude":39.916647,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123370,
-    "wof:geomhash":"33b16ddc57be4b4f7b1a34814f2ee126",
+    "wof:geomhash":"e7027676d655beb79fa9d63ff8e2ca1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108720589,
-    "wof:lastmodified":1566638391,
+    "wof:lastmodified":1695886312,
     "wof:name":"Al-Kamil",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/059/1/1108720591.geojson
+++ b/data/110/872/059/1/1108720591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.771967,
-    "geom:area_square_m":8419862627.484462,
+    "geom:area_square_m":8419862990.757814,
     "geom:bbox":"47.557404,27.460697,49.2681,28.702413",
     "geom:latitude":28.105392,
     "geom:longitude":48.203694,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123371,
-    "wof:geomhash":"07375d4c9ee705c7de8e0fb7c00b53db",
+    "wof:geomhash":"f7335484e3ec6fc43dc3ae7d553216d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720591,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886458,
     "wof:name":"Al-Khafji",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/059/5/1108720595.geojson
+++ b/data/110/872/059/5/1108720595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.528733,
-    "geom:area_square_m":17285841715.343662,
+    "geom:area_square_m":17285841715.343403,
     "geom:bbox":"46.5294080298,23.0742780847,48.1528958531,24.5824928381",
     "geom:latitude":23.87063,
     "geom:longitude":47.48261,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123372,
-    "wof:geomhash":"1dd33bde6718f9446a78e549c3768242",
+    "wof:geomhash":"29c7bf90ed7bd293961e3702a75938c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108720595,
-    "wof:lastmodified":1566638383,
+    "wof:lastmodified":1695886312,
     "wof:name":"Al-Kharj",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/059/7/1108720597.geojson
+++ b/data/110/872/059/7/1108720597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.952965,
-    "geom:area_square_m":11135391868.861103,
+    "geom:area_square_m":11135391467.253208,
     "geom:bbox":"49.787516,18.725174,52.002109,19.333681",
     "geom:latitude":19.092087,
     "geom:longitude":50.925713,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123373,
-    "wof:geomhash":"849301dda7fb0da8d6e9ca4a2823aa3f",
+    "wof:geomhash":"6d7f47b9292a1cf3cb9e530e2146ecea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720597,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886448,
     "wof:name":"Al-Kharkhir",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/059/9/1108720599.geojson
+++ b/data/110/872/059/9/1108720599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057732,
-    "geom:area_square_m":640283624.702861,
+    "geom:area_square_m":640283566.19332,
     "geom:bbox":"49.913664,25.984673,50.244836,26.421149",
     "geom:latitude":26.243408,
     "geom:longitude":50.113868,
@@ -85,12 +85,13 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123375,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"7640083db88d7e45b49b7eb5f38cc4d0",
+    "wof:geomhash":"eaece7d17b0a21414e17f26a85c38f38",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108720599,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Al-Khubar",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/060/1/1108720601.geojson
+++ b/data/110/872/060/1/1108720601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.136634,
-    "geom:area_square_m":13032530434.143408,
+    "geom:area_square_m":13032530198.270317,
     "geom:bbox":"41.590591,21.399472,43.376103,22.883504",
     "geom:latitude":21.984396,
     "geom:longitude":42.58965,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123376,
-    "wof:geomhash":"490124ee1c1c33789f1a64b613d9d67c",
+    "wof:geomhash":"831277ef151e31092b216c3288756680",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720601,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886448,
     "wof:name":"Al-Khurmah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/3/1108720603.geojson
+++ b/data/110/872/060/3/1108720603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.988634,
-    "geom:area_square_m":11456002566.757523,
+    "geom:area_square_m":11456002687.93107,
     "geom:bbox":"39.55401,19.689918,41.163263,20.997553",
     "geom:latitude":20.424267,
     "geom:longitude":40.405867,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123377,
-    "wof:geomhash":"8a091c858f64c676f7eb6cbd98dc4e12",
+    "wof:geomhash":"c94c5e9b4b72719f8a7e71707aae1424",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720603,
-    "wof:lastmodified":1627522742,
+    "wof:lastmodified":1695886448,
     "wof:name":"Al-Lith",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/060/5/1108720605.geojson
+++ b/data/110/872/060/5/1108720605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.22444,
-    "geom:area_square_m":25062786697.82785,
+    "geom:area_square_m":25062786723.436535,
     "geom:bbox":"38.667727,23.005741,40.630652,25.495667",
     "geom:latitude":24.3231,
     "geom:longitude":39.631858,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123378,
-    "wof:geomhash":"f28622a7ac9d82f8339a07ba974ec120",
+    "wof:geomhash":"a7524b2d730cb1e370919e2556e2dce3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720605,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886448,
     "wof:name":"Al-Madinah",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/7/1108720607.geojson
+++ b/data/110/872/060/7/1108720607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.184117,
-    "geom:area_square_m":24760062285.099182,
+    "geom:area_square_m":24760063134.068462,
     "geom:bbox":"39.779536,22.523459,42.157219,24.503756",
     "geom:latitude":23.532601,
     "geom:longitude":40.946947,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123379,
-    "wof:geomhash":"5287f1b2b0485ed799dc73b972989c75",
+    "wof:geomhash":"03877ee2f27798dc6b43c4a519e10652",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720607,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Mahd",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/060/9/1108720609.geojson
+++ b/data/110/872/060/9/1108720609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218309,
-    "geom:area_square_m":2552343095.892447,
+    "geom:area_square_m":2552342854.568588,
     "geom:bbox":"41.439876,18.760309,42.162596,19.361816",
     "geom:latitude":19.000829,
     "geom:longitude":41.823953,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123380,
-    "wof:geomhash":"655907650ddb2e0276fca781fbab6292",
+    "wof:geomhash":"6034e71299e2cccbeccd66801a34a00e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720609,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Majardah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/061/3/1108720613.geojson
+++ b/data/110/872/061/3/1108720613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.198419,
-    "geom:area_square_m":24346976969.617828,
+    "geom:area_square_m":24346976636.36166,
     "geom:bbox":"44.832132,25.380662,46.630442,27.700039",
     "geom:latitude":26.405012,
     "geom:longitude":45.636363,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123381,
-    "wof:geomhash":"ce28dd10390886ae923b3a5b4346e68f",
+    "wof:geomhash":"0f7984d8779ba4c063a4660d3f3c1ba0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720613,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886451,
     "wof:name":"Al-Majmaah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/061/5/1108720615.geojson
+++ b/data/110/872/061/5/1108720615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02899,
-    "geom:area_square_m":336426032.406234,
+    "geom:area_square_m":336426141.401212,
     "geom:bbox":"41.141298,20.028333,41.396964,20.450008",
     "geom:latitude":20.199065,
     "geom:longitude":41.273265,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123382,
-    "wof:geomhash":"c194f29a2f32fcf16da899b9102e5d1d",
+    "wof:geomhash":"01c5443248cd87c83f131c0e81a890a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720615,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Mandaq",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/061/7/1108720617.geojson
+++ b/data/110/872/061/7/1108720617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1725,
-    "geom:area_square_m":1922732717.856016,
+    "geom:area_square_m":1922732464.565176,
     "geom:bbox":"43.77132,25.330035,44.477418,25.952469",
     "geom:latitude":25.653354,
     "geom:longitude":44.148821,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123383,
-    "wof:geomhash":"1fad291ffe6cf21364d0219785349e4f",
+    "wof:geomhash":"c7807e022d6eb35130137c9e2aadaf0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720617,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Midhnab",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/061/9/1108720619.geojson
+++ b/data/110/872/061/9/1108720619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163113,
-    "geom:area_square_m":1898873765.356099,
+    "geom:area_square_m":1898873850.710874,
     "geom:bbox":"41.000194,19.446056,41.672038,19.976851",
     "geom:latitude":19.699784,
     "geom:longitude":41.363745,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123385,
-    "wof:geomhash":"2cec3dfd32e6ff5624f39317ab431f7e",
+    "wof:geomhash":"822c83e0ddc6ac2620f79c6bc270e416",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720619,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Mukhwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/062/1/1108720621.geojson
+++ b/data/110/872/062/1/1108720621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.474028,
-    "geom:area_square_m":5349162532.787649,
+    "geom:area_square_m":5349162914.22151,
     "geom:bbox":"45.779984,23.643004,46.660673,24.555839",
     "geom:latitude":24.131731,
     "geom:longitude":46.254391,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123386,
-    "wof:geomhash":"748b3f1a05d6daf35f55f6f1b08bfab5",
+    "wof:geomhash":"a7e0fe0315a1f3e516eae646521c18fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720621,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886451,
     "wof:name":"Al-Muzahimiya",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/062/3/1108720623.geojson
+++ b/data/110/872/062/3/1108720623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.495341,
-    "geom:area_square_m":16479918065.542677,
+    "geom:area_square_m":16479916885.446939,
     "geom:bbox":"47.848156,26.009043,49.201253,27.93858",
     "geom:latitude":26.962133,
     "geom:longitude":48.522671,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123387,
-    "wof:geomhash":"10cfbf35aa75261818b40b8568503f27",
+    "wof:geomhash":"685662ef68d504ff96a1272c060d32ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720623,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886449,
     "wof:name":"Al-Nuayriyah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/062/5/1108720625.geojson
+++ b/data/110/872/062/5/1108720625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094852,
-    "geom:area_square_m":1098839450.52375,
+    "geom:area_square_m":1098839584.601601,
     "geom:bbox":"41.210366,20.127823,41.456442,20.830865",
     "geom:latitude":20.463879,
     "geom:longitude":41.347314,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123388,
-    "wof:geomhash":"f81705ce6579101ccba2b15bcecd8b48",
+    "wof:geomhash":"a39649dc79358afdc93fae6922468ee9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720625,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886450,
     "wof:name":"Al-Qari",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/062/7/1108720627.geojson
+++ b/data/110/872/062/7/1108720627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058867,
-    "geom:area_square_m":650695159.402062,
+    "geom:area_square_m":650695796.700502,
     "geom:bbox":"49.746948,26.447862,50.092288,26.771677",
     "geom:latitude":26.627709,
     "geom:longitude":49.920851,
@@ -100,12 +100,13 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123389,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"1ad06c180afc98b7392ca255743c6ef3",
+    "wof:geomhash":"9562a889f612747429b200eb58899768",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108720627,
-    "wof:lastmodified":1636496658,
+    "wof:lastmodified":1695886726,
     "wof:name":"Al-Qatif",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/063/1/1108720631.geojson
+++ b/data/110/872/063/1/1108720631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144212,
-    "geom:area_square_m":1698291804.194011,
+    "geom:area_square_m":1698291769.271469,
     "geom:bbox":"41.92492,17.448723,42.475838,18.049528",
     "geom:latitude":17.75224,
     "geom:longitude":42.202145,
@@ -68,7 +68,7 @@
     "wof:concordances":{},
     "wof:country":"SA",
     "wof:created":1476123390,
-    "wof:geomhash":"d33ff43872e02cb2888ce04c70f9e997",
+    "wof:geomhash":"ffea94aee4481ec78475c2565ecc206a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108720631,
-    "wof:lastmodified":1627522741,
+    "wof:lastmodified":1695886447,
     "wof:name":"Alddarb",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/063/3/1108720633.geojson
+++ b/data/110/872/063/3/1108720633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.635539,
-    "geom:area_square_m":7418905481.333189,
+    "geom:area_square_m":7418905491.637903,
     "geom:bbox":"40.590363,18.461195,41.947548,19.838978",
     "geom:latitude":19.254243,
     "geom:longitude":41.389674,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123391,
-    "wof:geomhash":"256aa347166f026bb5fe0ab1f95db3bc",
+    "wof:geomhash":"21916ab4349a6911b90f23731e60405e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720633,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886450,
     "wof:name":"Al-Qunfidhah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/063/5/1108720635.geojson
+++ b/data/110/872/063/5/1108720635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.927817,
-    "geom:area_square_m":9826677128.458679,
+    "geom:area_square_m":9826677043.56422,
     "geom:bbox":"37.000897,29.943484,38.748978,31.749722",
     "geom:latitude":31.068534,
     "geom:longitude":37.841154,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JF.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123392,
-    "wof:geomhash":"a7eb41a927a3a26faedb7d59bb036bda",
+    "wof:geomhash":"56526996217c61102c8e67ca970565db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720635,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886451,
     "wof:name":"Al-Qurayyat",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/063/7/1108720637.geojson
+++ b/data/110/872/063/7/1108720637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.551659,
-    "geom:area_square_m":51723022290.752823,
+    "geom:area_square_m":51723021590.060875,
     "geom:bbox":"43.269926,21.929345,45.983979,24.670709",
     "geom:latitude":23.211908,
     "geom:longitude":44.651158,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123393,
-    "wof:geomhash":"cf453541263ec45c33802ccf48820355",
+    "wof:geomhash":"31da67b5ff0a526e9e071ecf815c29fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720637,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886451,
     "wof:name":"Al-Quwayiyah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/063/9/1108720639.geojson
+++ b/data/110/872/063/9/1108720639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.162223,
-    "geom:area_square_m":47637169800.668297,
+    "geom:area_square_m":47637170034.05864,
     "geom:bbox":"40.188916,20.323427,42.877341,23.694888",
     "geom:latitude":22.229407,
     "geom:longitude":41.416884,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123395,
-    "wof:geomhash":"a716528219cb8a1264610f0e315cb6ea",
+    "wof:geomhash":"309fc782de89ef4ab6006f2f93f8d553",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720639,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886452,
     "wof:name":"Al-Taif",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/064/1/1108720641.geojson
+++ b/data/110/872/064/1/1108720641.geojson
@@ -5,8 +5,8 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.592759,
-    "geom:area_square_m":28681276079.028393,
-    "geom:bbox":"36.63647459332364,25.42819540812438,38.96931437629917,27.49025225079175",
+    "geom:area_square_m":28681276079.02692,
+    "geom:bbox":"36.6364745933,25.4281954081,38.9693143763,27.4902522508",
     "geom:latitude":26.536694,
     "geom:longitude":37.90926,
     "iso:country":"SA",
@@ -121,9 +121,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123396,
-    "wof:geomhash":"899fc8f3caa8182764fecfe868426d3a",
+    "wof:geomhash":"0d02e11382b16c9f9d7db2c6b056fbd4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108720641,
-    "wof:lastmodified":1672944134,
+    "wof:lastmodified":1695886570,
     "wof:name":"AlUla",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/064/3/1108720643.geojson
+++ b/data/110/872/064/3/1108720643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.021076,
-    "geom:area_square_m":11305917997.224131,
+    "geom:area_square_m":11305917577.056858,
     "geom:bbox":"36.046276,25.758872,37.59189,27.182322",
     "geom:latitude":26.430184,
     "geom:longitude":36.822168,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123397,
-    "wof:geomhash":"2fbb8b98eb5cd4c7b735c5493c5d5f79",
+    "wof:geomhash":"b1e37b6fe40ae3bb4f8d099361a1f751",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720643,
-    "wof:lastmodified":1627522744,
+    "wof:lastmodified":1695886452,
     "wof:name":"Al-Wajh",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/064/5/1108720645.geojson
+++ b/data/110/872/064/5/1108720645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.634849,
-    "geom:area_square_m":7084315584.272566,
+    "geom:area_square_m":7084315579.885338,
     "geom:bbox":"41.57399,25.080096,43.265867,25.987962",
     "geom:latitude":25.516345,
     "geom:longitude":42.660117,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123398,
-    "wof:geomhash":"c30519dc0b00f9d6d1d412e1a06648c2",
+    "wof:geomhash":"e0d0086b42efc73083bad590c7206d3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720645,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886452,
     "wof:name":"An-Nabhaniyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/064/9/1108720649.geojson
+++ b/data/110/872/064/9/1108720649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183675,
-    "geom:area_square_m":2144019929.012511,
+    "geom:area_square_m":2144020162.360012,
     "geom:bbox":"41.957971,18.999108,42.539889,19.530272",
     "geom:latitude":19.262905,
     "geom:longitude":42.254683,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123400,
-    "wof:geomhash":"7e70d24ff509ccf5d04ac9df68e8c0df",
+    "wof:geomhash":"a260bb4aba07b6c3909d06f26c341734",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720649,
-    "wof:lastmodified":1627522743,
+    "wof:lastmodified":1695886450,
     "wof:name":"An-Namas",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/065/1/1108720651.geojson
+++ b/data/110/872/065/1/1108720651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.460096,
-    "geom:area_square_m":36776316113.765327,
+    "geom:area_square_m":36776316473.231102,
     "geom:bbox":"39.557945,29.149447,42.970291,31.996644",
     "geom:latitude":30.725434,
     "geom:longitude":41.35207,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123401,
-    "wof:geomhash":"ba461f655f62884fd14e25ea68567412",
+    "wof:geomhash":"83ce8736d0f0a1a3101f22f5f6e8ee0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720651,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886452,
     "wof:name":"Ar'ar",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/065/3/1108720653.geojson
+++ b/data/110/872/065/3/1108720653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.860832,
-    "geom:area_square_m":9640964220.348049,
+    "geom:area_square_m":9640964043.304274,
     "geom:bbox":"42.030363,24.47996,43.838186,25.980695",
     "geom:latitude":25.075152,
     "geom:longitude":42.9194,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123402,
-    "wof:geomhash":"b3d9ad40d973fdc359ec51c49b57ef8a",
+    "wof:geomhash":"aec5447e0e73411c277e057f704b4b70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720653,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886453,
     "wof:name":"Ar-Rass",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/065/5/1108720655.geojson
+++ b/data/110/872/065/5/1108720655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069009,
-    "geom:area_square_m":813162751.758742,
+    "geom:area_square_m":813162653.862687,
     "geom:bbox":"42.640687,17.518858,43.054727,17.796261",
     "geom:latitude":17.645806,
     "geom:longitude":42.826936,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123409,
-    "wof:geomhash":"e330ff0eaf7b9662b24c61adf02d03c3",
+    "wof:geomhash":"0d2789d70d6cf0eacf3bf614914caa92",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720655,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886453,
     "wof:name":"Ar-Rayth",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/065/7/1108720657.geojson
+++ b/data/110/872/065/7/1108720657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.121174,
-    "geom:area_square_m":12591754283.162376,
+    "geom:area_square_m":12591755221.622227,
     "geom:bbox":"45.017115,24.220342,47.743013,25.264332",
     "geom:latitude":24.732534,
     "geom:longitude":46.55204,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.RI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123410,
-    "wof:geomhash":"b5c53fa46957a6b7da7855ac61ff3069",
+    "wof:geomhash":"59970e62848125f7c7f860bf1259e72a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720657,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886458,
     "wof:name":"Ar-Riyad",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/065/9/1108720659.geojson
+++ b/data/110/872/065/9/1108720659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253728,
-    "geom:area_square_m":2819804162.987422,
+    "geom:area_square_m":2819804114.826417,
     "geom:bbox":"44.139734,25.488803,44.799518,26.589626",
     "geom:latitude":26.00124,
     "geom:longitude":44.470916,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123411,
-    "wof:geomhash":"7a65d0cea2dbc3fa2059f0b270629ec6",
+    "wof:geomhash":"e4fa7bfdfe647b0aa2ba3d1d95f2b140",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720659,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886453,
     "wof:name":"Ash-Shimasiyah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/066/1/1108720661.geojson
+++ b/data/110/872/066/1/1108720661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.106162,
-    "geom:area_square_m":12176691793.495354,
+    "geom:area_square_m":12176691833.341061,
     "geom:bbox":"41.713235,26.45185,43.450791,27.661879",
     "geom:latitude":27.094791,
     "geom:longitude":42.447799,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HA.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123412,
-    "wof:geomhash":"19910175db3a901d885d3ec5753b77f8",
+    "wof:geomhash":"475a01c49e08e7a829d4c91b458ec6e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720661,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886453,
     "wof:name":"As-Shinan",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/066/3/1108720663.geojson
+++ b/data/110/872/066/3/1108720663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.125866,
-    "geom:area_square_m":59447476684.897408,
+    "geom:area_square_m":59447475126.607552,
     "geom:bbox":"45.015133,19.211674,48.181079,21.487498",
     "geom:latitude":20.288098,
     "geom:longitude":46.452429,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123413,
-    "wof:geomhash":"6b421c08643ae885d55abd62b4f38716",
+    "wof:geomhash":"425f09ec4238fb5f16a838a1163e3868",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720663,
-    "wof:lastmodified":1627522745,
+    "wof:lastmodified":1695886454,
     "wof:name":"As-Sulayyil",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/7/1108720667.geojson
+++ b/data/110/872/066/7/1108720667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.486977,
-    "geom:area_square_m":5387714476.203178,
+    "geom:area_square_m":5387714674.048528,
     "geom:bbox":"44.381877,25.969883,45.09763,27.017581",
     "geom:latitude":26.524419,
     "geom:longitude":44.692572,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.ZU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123414,
-    "wof:geomhash":"9aac39beeb492ba65e32172e6a47ee38",
+    "wof:geomhash":"ac8355f870dd60e15716f2cb56620f73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720667,
-    "wof:lastmodified":1627522752,
+    "wof:lastmodified":1695886463,
     "wof:name":"Az-Zulfi",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/066/9/1108720669.geojson
+++ b/data/110/872/066/9/1108720669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126236,
-    "geom:area_square_m":1486027400.765586,
+    "geom:area_square_m":1486027211.291849,
     "geom:bbox":"43.596377,17.517098,43.922799,18.175909",
     "geom:latitude":17.821645,
     "geom:longitude":43.75346,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123415,
-    "wof:geomhash":"4bccbae7de6cd48dc0427a64a319810c",
+    "wof:geomhash":"4612d84f1181d6999ee3353fad7c06a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720669,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886454,
     "wof:name":"Badr al-Janub",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/067/1/1108720671.geojson
+++ b/data/110/872/067/1/1108720671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711797,
-    "geom:area_square_m":8054273280.92277,
+    "geom:area_square_m":8054273169.966339,
     "geom:bbox":"38.376705,23.15481,39.511702,24.502928",
     "geom:latitude":23.778186,
     "geom:longitude":38.972967,
@@ -109,9 +109,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123416,
-    "wof:geomhash":"75c0bf89b68f066052390f89e17e7713",
+    "wof:geomhash":"366a5716f14d8e319ecc069a7969fe05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108720671,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886454,
     "wof:name":"Badr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/067/3/1108720673.geojson
+++ b/data/110/872/067/3/1108720673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162926,
-    "geom:area_square_m":1896548135.436987,
+    "geom:area_square_m":1896547940.333606,
     "geom:bbox":"41.703518,19.335906,42.158894,20.091114",
     "geom:latitude":19.711788,
     "geom:longitude":41.945468,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123417,
-    "wof:geomhash":"95131768e601115430ed9b31d88f18f9",
+    "wof:geomhash":"712e1cd815dd03e6518224e9cdb50093",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720673,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886454,
     "wof:name":"Balqarn",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/067/5/1108720675.geojson
+++ b/data/110/872/067/5/1108720675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.300345,
-    "geom:area_square_m":25095823603.910385,
+    "geom:area_square_m":25095823340.509693,
     "geom:bbox":"41.785521,27.339671,44.367071,28.926008",
     "geom:latitude":28.079146,
     "geom:longitude":42.898108,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123418,
-    "wof:geomhash":"9281d761437e1f3be15baa8c53ec749f",
+    "wof:geomhash":"4bcb81791f9571f0a6f11c2ceaec93d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720675,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886454,
     "wof:name":"Baqa",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/067/7/1108720677.geojson
+++ b/data/110/872/067/7/1108720677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158559,
-    "geom:area_square_m":1869631589.038082,
+    "geom:area_square_m":1869630733.250168,
     "geom:bbox":"42.283815,17.017916,42.777797,17.817514",
     "geom:latitude":17.522887,
     "geom:longitude":42.502081,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123419,
-    "wof:geomhash":"b4ce70b929d20710c18971c71a462800",
+    "wof:geomhash":"1fbfeefbb0d1364a031f63bdacceeee8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720677,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886454,
     "wof:name":"Baysh",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/067/9/1108720679.geojson
+++ b/data/110/872/067/9/1108720679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126513,
-    "geom:area_square_m":1469994284.511765,
+    "geom:area_square_m":1469994248.776489,
     "geom:bbox":"41.500664,19.699869,41.975208,20.301298",
     "geom:latitude":20.001814,
     "geom:longitude":41.731126,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123420,
-    "wof:geomhash":"4cc57e887c9bca7e8dec4e9f7ec1ad40",
+    "wof:geomhash":"ea5d4b141dc2d505261dfa1aa1568e69",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720679,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886455,
     "wof:name":"Biljurashi",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/068/1/1108720681.geojson
+++ b/data/110/872/068/1/1108720681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.103836,
-    "geom:area_square_m":12839007285.717012,
+    "geom:area_square_m":12839007640.494631,
     "geom:bbox":"41.873487,18.991149,43.110071,20.589775",
     "geom:latitude":19.836604,
     "geom:longitude":42.56768,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123421,
-    "wof:geomhash":"148cb841a0bfed74341f93a0d63ff009",
+    "wof:geomhash":"d7c2f53ed23f6bce5e0a96c279e1f7df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720681,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886455,
     "wof:name":"Bishah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/068/5/1108720685.geojson
+++ b/data/110/872/068/5/1108720685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.578169,
-    "geom:area_square_m":6421901615.472554,
+    "geom:area_square_m":6421901419.08118,
     "geom:bbox":"49.080282,25.617281,50.137093,26.651458",
     "geom:latitude":26.067349,
     "geom:longitude":49.546259,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123422,
-    "wof:geomhash":"80b701c78b7fa7ce80afcb576820ae20",
+    "wof:geomhash":"fe4f1db03b26351278aa880ff8baeb90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720685,
-    "wof:lastmodified":1627522740,
+    "wof:lastmodified":1695886445,
     "wof:name":"Buqayq",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/068/7/1108720687.geojson
+++ b/data/110/872/068/7/1108720687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.886011,
-    "geom:area_square_m":31892233912.602997,
+    "geom:area_square_m":31892233970.987362,
     "geom:bbox":"41.455996,24.986709,44.984261,28.252979",
     "geom:latitude":26.646941,
     "geom:longitude":43.504925,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123423,
-    "wof:geomhash":"a4a45131a21bfaedf4e0bb5b3d5446fb",
+    "wof:geomhash":"b5f01ee3289831ff903212f99b5bf985",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720687,
-    "wof:lastmodified":1636496659,
+    "wof:lastmodified":1695886726,
     "wof:name":"Buraydah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/068/9/1108720689.geojson
+++ b/data/110/872/068/9/1108720689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0274,
-    "geom:area_square_m":323779651.325467,
+    "geom:area_square_m":323779688.740193,
     "geom:bbox":"42.677623,17.014148,42.947416,17.244838",
     "geom:latitude":17.130753,
     "geom:longitude":42.823441,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123425,
-    "wof:geomhash":"ea3c8f8af706e91386bc4ed4e66739e1",
+    "wof:geomhash":"1ef2eb9b4edc07cee7bca74d3880e5dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720689,
-    "wof:lastmodified":1627522746,
+    "wof:lastmodified":1695886455,
     "wof:name":"Damad",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/069/1/1108720691.geojson
+++ b/data/110/872/069/1/1108720691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.963471,
-    "geom:area_square_m":31926528668.411663,
+    "geom:area_square_m":31926528668.842224,
     "geom:bbox":"38.1809,28.370765,40.937218,31.296151",
     "geom:latitude":29.390355,
     "geom:longitude":39.532097,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JF.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123426,
-    "wof:geomhash":"4531d99eb330be11d6d7a050d69d2d32",
+    "wof:geomhash":"c488be99e45deb66ad25d802473241b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720691,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886455,
     "wof:name":"Dawamat al-Jandal",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/069/3/1108720693.geojson
+++ b/data/110/872/069/3/1108720693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.065963,
-    "geom:area_square_m":11688484006.851379,
+    "geom:area_square_m":11688484006.851313,
     "geom:bbox":"35.0454353738,26.8102466205,36.7301070749,28.3121450359",
     "geom:latitude":27.52694,
     "geom:longitude":35.991984,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.DU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123427,
-    "wof:geomhash":"a0b065424761121a7915cadd8ab7cbc9",
+    "wof:geomhash":"808142eaec6789dc2c6ac7fc232d648d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108720693,
-    "wof:lastmodified":1566638389,
+    "wof:lastmodified":1695886312,
     "wof:name":"Duba",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/069/5/1108720695.geojson
+++ b/data/110/872/069/5/1108720695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214519,
-    "geom:area_square_m":2410581440.762859,
+    "geom:area_square_m":2410581942.974004,
     "geom:bbox":"45.713585,24.390044,46.656119,24.948223",
     "geom:latitude":24.663771,
     "geom:longitude":46.099291,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123428,
-    "wof:geomhash":"acb41e9ee4b6ab5de8836d1a5e55a6b3",
+    "wof:geomhash":"31ba53a4495d84dc7767b88eb53fb1e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720695,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886456,
     "wof:name":"Duruma",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/069/7/1108720697.geojson
+++ b/data/110/872/069/7/1108720697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060962,
-    "geom:area_square_m":721692858.474314,
+    "geom:area_square_m":721692751.338561,
     "geom:bbox":"41.564556,16.531195,42.192028,17.07625",
     "geom:latitude":16.783139,
     "geom:longitude":41.936899,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123429,
-    "wof:geomhash":"6b360fb5be2a239ffd0d3fc7fe12482e",
+    "wof:geomhash":"33bdf386851acf730981cf65e4dc585e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720697,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886456,
     "wof:name":"Farasan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/069/9/1108720699.geojson
+++ b/data/110/872/069/9/1108720699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.886973,
-    "geom:area_square_m":42335181830.376312,
+    "geom:area_square_m":42335181848.014374,
     "geom:bbox":"44.366465,27.007156,47.720415,29.130772",
     "geom:latitude":28.254852,
     "geom:longitude":46.080999,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123430,
-    "wof:geomhash":"ae040f9b913f3c0bad845b874650d8dd",
+    "wof:geomhash":"d7c8993a0bb693ffb2309fc947a30d4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720699,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886456,
     "wof:name":"Hafar al-Batin",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/070/3/1108720703.geojson
+++ b/data/110/872/070/3/1108720703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.839336,
-    "geom:area_square_m":52949013185.457375,
+    "geom:area_square_m":52949014113.433716,
     "geom:bbox":"39.117649,26.101995,42.302826,28.922846",
     "geom:latitude":27.758772,
     "geom:longitude":40.769777,
@@ -193,9 +193,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123431,
-    "wof:geomhash":"48e6a2530fe7e55fa29b3817e17f8849",
+    "wof:geomhash":"75c2d273dec68e6cf1ffaabd8c3f2514",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1108720703,
-    "wof:lastmodified":1636496658,
+    "wof:lastmodified":1695886726,
     "wof:name":"Ha'il",
     "wof:parent_id":85676831,
     "wof:placetype":"county",

--- a/data/110/872/070/5/1108720705.geojson
+++ b/data/110/872/070/5/1108720705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.521811,
-    "geom:area_square_m":5642798321.368463,
+    "geom:area_square_m":5642798748.950384,
     "geom:bbox":"34.737083,28.393715,35.975351,29.357243",
     "geom:latitude":29.008804,
     "geom:longitude":35.357235,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123432,
-    "wof:geomhash":"4d2701ad6885905dab749d9b4b7a1597",
+    "wof:geomhash":"f72a29bf07535ad60336f02ad674b9a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720705,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886456,
     "wof:name":"Haqil",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/070/7/1108720707.geojson
+++ b/data/110/872/070/7/1108720707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.663016,
-    "geom:area_square_m":7534027166.246427,
+    "geom:area_square_m":7534028094.593327,
     "geom:bbox":"45.926423,22.778364,47.328315,23.760702",
     "geom:latitude":23.222918,
     "geom:longitude":46.693413,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123434,
-    "wof:geomhash":"ce12c25d22f5c2cde8e7bdd8d5bdcb78",
+    "wof:geomhash":"4fd2e5d650a9299512dd59b7b4987b30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720707,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Hawtat Bani Tamim",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/070/9/1108720709.geojson
+++ b/data/110/872/070/9/1108720709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152958,
-    "geom:area_square_m":1800976485.383337,
+    "geom:area_square_m":1800976861.770643,
     "geom:bbox":"43.841017,17.584422,44.572523,17.94606",
     "geom:latitude":17.783341,
     "geom:longitude":44.211706,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123435,
-    "wof:geomhash":"6f4ddd52669fccb915da7ba0839a8ec3",
+    "wof:geomhash":"c5bf5c3718b0f26c83b375de98070652",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720709,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Hubuna",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/071/1/1108720711.geojson
+++ b/data/110/872/071/1/1108720711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313953,
-    "geom:area_square_m":3512167615.431535,
+    "geom:area_square_m":3512167651.973964,
     "geom:bbox":"45.704053,24.797914,46.658429,25.662387",
     "geom:latitude":25.214915,
     "geom:longitude":46.248677,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123436,
-    "wof:geomhash":"8bdcb35943f8a73b9e79023582b0204c",
+    "wof:geomhash":"c9a95ceab30c0f0aa38d107591ebcf20",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720711,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Huraymila",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/071/3/1108720713.geojson
+++ b/data/110/872/071/3/1108720713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027369,
-    "geom:area_square_m":323526906.942383,
+    "geom:area_square_m":323526559.693419,
     "geom:bbox":"42.534557,16.811874,43.156514,17.313881",
     "geom:latitude":17.060319,
     "geom:longitude":42.825238,
@@ -172,9 +172,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123437,
-    "wof:geomhash":"64929dfcb0d1fef20151887d5729dc8d",
+    "wof:geomhash":"20fd9c1ea212b488ecb3c02deeb5436c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":1108720713,
-    "wof:lastmodified":1636496658,
+    "wof:lastmodified":1695886726,
     "wof:name":"Jizan",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/071/5/1108720715.geojson
+++ b/data/110/872/071/5/1108720715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298403,
-    "geom:area_square_m":3429321474.699464,
+    "geom:area_square_m":3429320706.080729,
     "geom:bbox":"38.917862,20.886028,39.452437,22.323637",
     "geom:latitude":21.654899,
     "geom:longitude":39.199022,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123438,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"b1b848a0597afbf5af757861a1671f46",
+    "wof:geomhash":"d4e117c5431f5119534406d628e3281f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108720715,
-    "wof:lastmodified":1627522747,
+    "wof:lastmodified":1695886456,
     "wof:name":"Jiddah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/071/7/1108720717.geojson
+++ b/data/110/872/071/7/1108720717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.527837,
-    "geom:area_square_m":6182646965.228278,
+    "geom:area_square_m":6182647334.998175,
     "geom:bbox":"42.476878,18.148913,43.460489,19.124225",
     "geom:latitude":18.688004,
     "geom:longitude":42.907195,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123439,
-    "wof:geomhash":"cbf89302420de3d802bcc8283706162c",
+    "wof:geomhash":"5dcbcf3f587038f2a5b09fe115e79aa1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720717,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Khamis Mushayt",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/072/1/1108720721.geojson
+++ b/data/110/872/072/1/1108720721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.880679,
-    "geom:area_square_m":20919583120.979153,
+    "geom:area_square_m":20919583120.979404,
     "geom:bbox":"38.4291238365,24.6417710108,39.9800713844,26.8910418481",
     "geom:latitude":25.893262,
     "geom:longitude":39.367477,
@@ -139,9 +139,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123440,
-    "wof:geomhash":"3ec370e2484e5ad8c8a7d0175f3e1281",
+    "wof:geomhash":"351ca9d09f78f664f1296637f883eb26",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720721,
-    "wof:lastmodified":1566638379,
+    "wof:lastmodified":1695886311,
     "wof:name":"Khaybar",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/072/3/1108720723.geojson
+++ b/data/110/872/072/3/1108720723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.853874,
-    "geom:area_square_m":10060555012.031315,
+    "geom:area_square_m":10060554844.656689,
     "geom:bbox":"44.348016,17.26706,45.980643,18.136604",
     "geom:latitude":17.662496,
     "geom:longitude":45.266249,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123441,
-    "wof:geomhash":"84f89669595ec872a0414069a897db83",
+    "wof:geomhash":"ae2779d8c7893e99fe8703eb5d493f79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720723,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Khubash",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/072/5/1108720725.geojson
+++ b/data/110/872/072/5/1108720725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.36477,
-    "geom:area_square_m":4173449411.503699,
+    "geom:area_square_m":4173449156.486501,
     "geom:bbox":"39.225891,21.870055,39.938381,22.813814",
     "geom:latitude":22.287293,
     "geom:longitude":39.577284,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123442,
-    "wof:geomhash":"cc1438071a408475547a140888ff964e",
+    "wof:geomhash":"c720f34e7c269dece442e134710cab32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108720725,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886457,
     "wof:name":"Khulays",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/7/1108720727.geojson
+++ b/data/110/872/072/7/1108720727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.748286,
-    "geom:area_square_m":8624728880.060392,
+    "geom:area_square_m":8624728562.886652,
     "geom:bbox":"39.313791,20.615665,40.473299,21.849075",
     "geom:latitude":21.228791,
     "geom:longitude":39.830291,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123444,
-    "wof:geomhash":"1ea3ddf387cad5b686a97fca53b3bf8d",
+    "wof:geomhash":"af6bc76dc2af1aab8e9103df5ee375ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720727,
-    "wof:lastmodified":1627522748,
+    "wof:lastmodified":1695886458,
     "wof:name":"Makka",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/072/9/1108720729.geojson
+++ b/data/110/872/072/9/1108720729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375802,
-    "geom:area_square_m":4407383063.480074,
+    "geom:area_square_m":4407383069.497556,
     "geom:bbox":"41.363093,17.889018,42.481185,18.841355",
     "geom:latitude":18.473494,
     "geom:longitude":41.942376,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123445,
-    "wof:geomhash":"b2bd6991a513c5ebffe094707647e8e2",
+    "wof:geomhash":"f696ed06778dea297143a7ab1fc8cac8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720729,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886458,
     "wof:name":"Muhayil",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/073/1/1108720731.geojson
+++ b/data/110/872/073/1/1108720731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.674523,
-    "geom:area_square_m":19614987204.914196,
+    "geom:area_square_m":19614988592.736549,
     "geom:bbox":"43.685888,17.330556,47.660488,19.334497",
     "geom:latitude":18.674735,
     "geom:longitude":46.508115,
@@ -184,9 +184,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123446,
-    "wof:geomhash":"f4547f1393f76e2ebf7013a96385b39f",
+    "wof:geomhash":"7155fdca2e73849b8c2899c2e4411362",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":1108720731,
-    "wof:lastmodified":1636496659,
+    "wof:lastmodified":1695886727,
     "wof:name":"Najran",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/073/3/1108720733.geojson
+++ b/data/110/872/073/3/1108720733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.592461,
-    "geom:area_square_m":28508162339.742985,
+    "geom:area_square_m":28508162273.733318,
     "geom:bbox":"45.779915,26.29081,48.170635,28.022526",
     "geom:latitude":27.209992,
     "geom:longitude":47.06075,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123447,
-    "wof:geomhash":"2b7409c732cb5e8773a81cda8bef8fb8",
+    "wof:geomhash":"7fa8da7a16ea800e46ff520c1887472c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720733,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886458,
     "wof:name":"Qaryah al-Ulya",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/073/5/1108720735.geojson
+++ b/data/110/872/073/5/1108720735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199088,
-    "geom:area_square_m":2312986433.237567,
+    "geom:area_square_m":2312986843.941001,
     "geom:bbox":"40.837534,19.672176,41.436177,20.366825",
     "geom:latitude":20.021032,
     "geom:longitude":41.108364,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.BA.QI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123448,
-    "wof:geomhash":"8be7f61593ec4f3e0c8cb832e20aa5ef",
+    "wof:geomhash":"0fc2c15280fc42b8b673c5dc8a8e05c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720735,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886459,
     "wof:name":"Qilwah",
     "wof:parent_id":85676847,
     "wof:placetype":"county",

--- a/data/110/872/073/9/1108720739.geojson
+++ b/data/110/872/073/9/1108720739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.596362,
-    "geom:area_square_m":6792178015.899342,
+    "geom:area_square_m":6792178015.898295,
     "geom:bbox":"38.643749237,22.3174254163,39.8828915265,23.4961803602",
     "geom:latitude":22.913884,
     "geom:longitude":39.230148,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123449,
-    "wof:geomhash":"3a678a0365598356a208d4257c06a2e4",
+    "wof:geomhash":"f49deb876b9c265bea913d0aba1bc813",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108720739,
-    "wof:lastmodified":1566638376,
+    "wof:lastmodified":1695886311,
     "wof:name":"Rabigh",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/074/1/1108720741.geojson
+++ b/data/110/872/074/1/1108720741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.194404,
-    "geom:area_square_m":45274770817.386826,
+    "geom:area_square_m":45274771267.519035,
     "geom:bbox":"41.400469,28.255783,45.731338,30.483964",
     "geom:latitude":29.194343,
     "geom:longitude":43.544794,
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HS.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123451,
-    "wof:geomhash":"5915cdcf65ec446c65390be882c28154",
+    "wof:geomhash":"6cc857f3f2b5e0e41d01daf96ff4d19b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108720741,
-    "wof:lastmodified":1636496659,
+    "wof:lastmodified":1695886727,
     "wof:name":"Rafha",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/074/3/1108720743.geojson
+++ b/data/110/872/074/3/1108720743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.906489,
-    "geom:area_square_m":21994219171.787266,
+    "geom:area_square_m":21994218533.86277,
     "geom:bbox":"41.878152,20.253979,43.829112,22.103988",
     "geom:latitude":21.092314,
     "geom:longitude":42.802703,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.RN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123452,
-    "wof:geomhash":"bbe6242434c7ae095df5e2532a729695",
+    "wof:geomhash":"88218cd97fa79fbb1484ebc6aa79062c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720743,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886459,
     "wof:name":"Ranyah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/074/5/1108720745.geojson
+++ b/data/110/872/074/5/1108720745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022616,
-    "geom:area_square_m":249659862.938057,
+    "geom:area_square_m":249660278.0021,
     "geom:bbox":"49.800258,26.625389,50.164612,26.857889",
     "geom:latitude":26.776311,
     "geom:longitude":49.957772,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.SH.RT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123453,
-    "wof:geomhash":"38b512ff85985ca3d49711ff16aa3c62",
+    "wof:geomhash":"281d651adafda1dba9062f29a47bffac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720745,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886459,
     "wof:name":"Ras Tannurah",
     "wof:parent_id":85676819,
     "wof:placetype":"county",

--- a/data/110/872/074/7/1108720747.geojson
+++ b/data/110/872/074/7/1108720747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15677,
-    "geom:area_square_m":1842574454.79036,
+    "geom:area_square_m":1842574805.42044,
     "geom:bbox":"41.78177,17.765034,42.368037,18.441292",
     "geom:latitude":18.098079,
     "geom:longitude":42.143317,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123454,
-    "wof:geomhash":"0c1fe76f747e0c737ed5e3bec8b3f2dc",
+    "wof:geomhash":"ae488ff9f7cc93dca5c44013b69b1ceb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720747,
-    "wof:lastmodified":1627522749,
+    "wof:lastmodified":1695886459,
     "wof:name":"Rijal Alma",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/074/9/1108720749.geojson
+++ b/data/110/872/074/9/1108720749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.38586,
-    "geom:area_square_m":4290580102.986872,
+    "geom:area_square_m":4290580501.93393,
     "geom:bbox":"41.300329,25.188509,43.5915,26.582823",
     "geom:latitude":25.936921,
     "geom:longitude":42.222498,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.RK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123455,
-    "wof:geomhash":"e2f66f929fbf2947f29da3ee4ee436e1",
+    "wof:geomhash":"80874f4d28f00f927cdd0b534cd30f66",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720749,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886459,
     "wof:name":"Riyadh al-Khabra",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/075/1/1108720751.geojson
+++ b/data/110/872/075/1/1108720751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.716119,
-    "geom:area_square_m":19113267643.51236,
+    "geom:area_square_m":19113267333.627918,
     "geom:bbox":"46.375456,24.795863,47.775351,26.677288",
     "geom:latitude":25.744421,
     "geom:longitude":47.074405,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123456,
-    "wof:geomhash":"6b774f174bb906f63b53eb634b43add2",
+    "wof:geomhash":"622ee3b6f94de980794533e02c87207f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108720751,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886459,
     "wof:name":"Rumah",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/075/3/1108720753.geojson
+++ b/data/110/872/075/3/1108720753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139832,
-    "geom:area_square_m":1651348672.958505,
+    "geom:area_square_m":1651348672.95857,
     "geom:bbox":"42.3802872159,16.9975130941,42.9125676524,17.4591979734",
     "geom:latitude":17.241819,
     "geom:longitude":42.638389,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123458,
-    "wof:geomhash":"8a787f13a390cd6c6e78227879284da0",
+    "wof:geomhash":"06bbe3d688f035a086fd3604fd1a50ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108720753,
-    "wof:lastmodified":1566638379,
+    "wof:lastmodified":1695886311,
     "wof:name":"Sabya",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/075/7/1108720757.geojson
+++ b/data/110/872/075/7/1108720757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.267367,
-    "geom:area_square_m":45632597250.30191,
+    "geom:area_square_m":45632597571.771477,
     "geom:bbox":"37.489985,28.913696,41.993367,31.000107",
     "geom:latitude":30.137501,
     "geom:longitude":39.939805,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JF.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123459,
-    "wof:geomhash":"befbb70a13bde96a15e642912b93113c",
+    "wof:geomhash":"0217c95fe6700d366dd4a111facada5a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720757,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886460,
     "wof:name":"Sakaka",
     "wof:parent_id":85676843,
     "wof:placetype":"county",

--- a/data/110/872/075/9/1108720759.geojson
+++ b/data/110/872/075/9/1108720759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0901,
-    "geom:area_square_m":1067830921.372284,
+    "geom:area_square_m":1067831137.757949,
     "geom:bbox":"42.707863,16.379528,43.193,16.765465",
     "geom:latitude":16.570418,
     "geom:longitude":42.934601,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"SA.JZ.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123460,
-    "wof:geomhash":"3e9fc93befc33de5cf2ef01d1c9fbd46",
+    "wof:geomhash":"9836be246758fa5322b34f5d3addcf92",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108720759,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886460,
     "wof:name":"Samtah",
     "wof:parent_id":85676853,
     "wof:placetype":"county",

--- a/data/110/872/076/1/1108720761.geojson
+++ b/data/110/872/076/1/1108720761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.2609,
-    "geom:area_square_m":3068538950.685111,
+    "geom:area_square_m":3068539544.787499,
     "geom:bbox":"42.860867,17.581806,43.466613,18.461577",
     "geom:latitude":17.978621,
     "geom:longitude":43.160805,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123461,
-    "wof:geomhash":"60809573c72ae9f8149f96eceffb9f89",
+    "wof:geomhash":"c9134380df75cb41d81fb5c5a8aa6740",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720761,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886460,
     "wof:name":"Sarat Abidah",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/076/3/1108720763.geojson
+++ b/data/110/872/076/3/1108720763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.448739,
-    "geom:area_square_m":5013364616.942466,
+    "geom:area_square_m":5013364078.049443,
     "geom:bbox":"44.66316,24.91776,45.750096,25.809883",
     "geom:latitude":25.375748,
     "geom:longitude":45.136995,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123462,
-    "wof:geomhash":"2a367294a8ef47be07ffe2faa2675591",
+    "wof:geomhash":"c7dcd6f52d42c4699569d0eed1fe5a3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720763,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886460,
     "wof:name":"Shaqra",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/076/5/1108720765.geojson
+++ b/data/110/872/076/5/1108720765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.254318,
-    "geom:area_square_m":61652590822.943085,
+    "geom:area_square_m":61652590822.942482,
     "geom:bbox":"45.270615241,16.95,50.1804637108,19.332826593",
     "geom:latitude":18.380328,
     "geom:longitude":47.430537,
@@ -106,9 +106,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123463,
-    "wof:geomhash":"124b3309fa0b5d2c029cf6f1d0e8d7b0",
+    "wof:geomhash":"30906f00ba7158d4b41e125f1820c0d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108720765,
-    "wof:lastmodified":1566638364,
+    "wof:lastmodified":1695886311,
     "wof:name":"Sharurah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/076/7/1108720767.geojson
+++ b/data/110/872/076/7/1108720767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.171553,
-    "geom:area_square_m":56095481095.878098,
+    "geom:area_square_m":56095481048.050026,
     "geom:bbox":"34.572918,27.311267,38.791957,29.991911",
     "geom:latitude":28.686343,
     "geom:longitude":36.854245,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123464,
-    "wof:geomhash":"9d8788182101dc5f7e01cdfcd604e081",
+    "wof:geomhash":"da4712cd1a4761f9425753f1fe23c42c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108720767,
-    "wof:lastmodified":1636496658,
+    "wof:lastmodified":1695886726,
     "wof:name":"Tabuk",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/076/9/1108720769.geojson
+++ b/data/110/872/076/9/1108720769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.414397,
-    "geom:area_square_m":28120180901.771072,
+    "geom:area_square_m":28120180424.083717,
     "geom:bbox":"42.897247,18.255187,44.484583,20.802293",
     "geom:latitude":19.616725,
     "geom:longitude":43.626645,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123466,
-    "wof:geomhash":"dcb140d25a3b3149b3b00b31d17d7af2",
+    "wof:geomhash":"892507440876d588f35d5c4fc48a2c7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720769,
-    "wof:lastmodified":1627522750,
+    "wof:lastmodified":1695886460,
     "wof:name":"Tathlith",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/110/872/077/1/1108720771.geojson
+++ b/data/110/872/077/1/1108720771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.397637,
-    "geom:area_square_m":37172235200.9394,
+    "geom:area_square_m":37172235200.938782,
     "geom:bbox":"37.3579141007,26.7699213909,40.0605051217,28.939623251",
     "geom:latitude":27.769867,
     "geom:longitude":38.654307,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.TY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123467,
-    "wof:geomhash":"0abf88464f0823aba612996a6124c3cc",
+    "wof:geomhash":"6ff203a55a6016a20b44953c73e6841d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108720771,
-    "wof:lastmodified":1566638359,
+    "wof:lastmodified":1695886310,
     "wof:name":"Tayma",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/077/5/1108720775.geojson
+++ b/data/110/872/077/5/1108720775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355282,
-    "geom:area_square_m":3964930855.624483,
+    "geom:area_square_m":3964931091.237458,
     "geom:bbox":"45.62874,24.914596,46.467354,26.059831",
     "geom:latitude":25.505842,
     "geom:longitude":46.041231,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123468,
-    "wof:geomhash":"280d81f6eadb3dcac3dee8c6848dfe46",
+    "wof:geomhash":"24ca12ea824219edf2311749faf73743",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720775,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886460,
     "wof:name":"Thadiq",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/077/7/1108720777.geojson
+++ b/data/110/872/077/7/1108720777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.750938,
-    "geom:area_square_m":8821859001.118402,
+    "geom:area_square_m":8821859001.118149,
     "geom:bbox":"43.7364195907,17.8588869534,45.4462585242,18.6259855528",
     "geom:latitude":18.18148,
     "geom:longitude":44.628285,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123469,
-    "wof:geomhash":"4b9d08c29f771f2707ed676b42fff518",
+    "wof:geomhash":"54ee4d048a89e49915cf09bf2f2895eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108720777,
-    "wof:lastmodified":1566638358,
+    "wof:lastmodified":1695886310,
     "wof:name":"Thar",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/077/9/1108720779.geojson
+++ b/data/110/872/077/9/1108720779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.852189,
-    "geom:area_square_m":19525447537.763157,
+    "geom:area_square_m":19525446280.468166,
     "geom:bbox":"37.913392,30.859217,40.134783,32.154284",
     "geom:latitude":31.509583,
     "geom:longitude":39.004458,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.HS.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123470,
-    "wof:geomhash":"8b813e7b43dc1c6cbeae777453d739e3",
+    "wof:geomhash":"28df1aa52c4698550ebd22ca48c0d754",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720779,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Turayf",
     "wof:parent_id":85676837,
     "wof:placetype":"county",

--- a/data/110/872/078/1/1108720781.geojson
+++ b/data/110/872/078/1/1108720781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.616028,
-    "geom:area_square_m":7100407592.78849,
+    "geom:area_square_m":7100407115.736799,
     "geom:bbox":"41.14889,20.574949,42.040777,21.86002",
     "geom:latitude":21.22667,
     "geom:longitude":41.598941,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MK.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123471,
-    "wof:geomhash":"501aaaa98a33b676ddb22c16ad1bcc0c",
+    "wof:geomhash":"324c2a107e4800ebdbaa3623488a38f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108720781,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Turubah",
     "wof:parent_id":85676857,
     "wof:placetype":"county",

--- a/data/110/872/078/3/1108720783.geojson
+++ b/data/110/872/078/3/1108720783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.881376,
-    "geom:area_square_m":9852154402.018492,
+    "geom:area_square_m":9852153028.737829,
     "geom:bbox":"36.486221,24.56654,38.035559,25.908964",
     "geom:latitude":25.308725,
     "geom:longitude":37.404664,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.TB.UM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123472,
-    "wof:geomhash":"00898dd1776deac31c3419ea729580ca",
+    "wof:geomhash":"349f0a97e00ce9eab2f93da2269cbd65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720783,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Umluj",
     "wof:parent_id":85676833,
     "wof:placetype":"county",

--- a/data/110/872/078/5/1108720785.geojson
+++ b/data/110/872/078/5/1108720785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17076,
-    "geom:area_square_m":1898636311.160678,
+    "geom:area_square_m":1898636153.582861,
     "geom:bbox":"43.778027,25.610935,44.268723,26.218807",
     "geom:latitude":25.94711,
     "geom:longitude":44.01183,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123473,
-    "wof:geomhash":"b8c929f6e52c42e9235451790b2a5cb7",
+    "wof:geomhash":"f0c5839e8d898d821f4e28753dc065a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720785,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Unayzah",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/7/1108720787.geojson
+++ b/data/110/872/078/7/1108720787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.235935,
-    "geom:area_square_m":2606726642.483817,
+    "geom:area_square_m":2606726357.747513,
     "geom:bbox":"42.740378,26.369878,43.776972,26.959359",
     "geom:latitude":26.681165,
     "geom:longitude":43.234824,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.QS.UJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123474,
-    "wof:geomhash":"0f83f0e94f67fe59cd34581b0cce126a",
+    "wof:geomhash":"8d6cabfd0585d1af48549339fe89ac81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720787,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Uyun al-Jiwa",
     "wof:parent_id":85676827,
     "wof:placetype":"county",

--- a/data/110/872/078/9/1108720789.geojson
+++ b/data/110/872/078/9/1108720789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.976329,
-    "geom:area_square_m":45880096191.209251,
+    "geom:area_square_m":45880097663.454964,
     "geom:bbox":"43.427806,19.306348,45.810401,22.575581",
     "geom:latitude":21.057339,
     "geom:longitude":44.606875,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.RI.WD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123475,
-    "wof:geomhash":"392445d8fe57926df393448a480b7498",
+    "wof:geomhash":"405927a303ce74cc212a5903d4922aed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720789,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886461,
     "wof:name":"Wadi ad-Dwasir",
     "wof:parent_id":85676813,
     "wof:placetype":"county",

--- a/data/110/872/079/3/1108720793.geojson
+++ b/data/110/872/079/3/1108720793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.104054,
-    "geom:area_square_m":12919633859.571539,
+    "geom:area_square_m":12919633650.131891,
     "geom:bbox":"43.918585,18.183455,45.360265,19.450422",
     "geom:latitude":18.848152,
     "geom:longitude":44.717026,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SA.NJ.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123477,
-    "wof:geomhash":"9618da1856dbf8df88371caf3fb04b62",
+    "wof:geomhash":"85c7263314c946d215516b77ea6e77ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108720793,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886462,
     "wof:name":"Yadamah",
     "wof:parent_id":85676809,
     "wof:placetype":"county",

--- a/data/110/872/079/5/1108720795.geojson
+++ b/data/110/872/079/5/1108720795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.653992,
-    "geom:area_square_m":18572957519.344231,
+    "geom:area_square_m":18572957778.872482,
     "geom:bbox":"37.367522,23.643974,38.897771,25.670581",
     "geom:latitude":24.748175,
     "geom:longitude":38.234088,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.MD.YB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123478,
-    "wof:geomhash":"7ee90955c5f0b0b17ee45ff5864845dd",
+    "wof:geomhash":"d328b5f47127da585b009aed1fc081a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720795,
-    "wof:lastmodified":1627522751,
+    "wof:lastmodified":1695886462,
     "wof:name":"Yanbu al-Bahr",
     "wof:parent_id":85676825,
     "wof:placetype":"county",

--- a/data/110/872/079/7/1108720797.geojson
+++ b/data/110/872/079/7/1108720797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.247674,
-    "geom:area_square_m":2914771050.184605,
+    "geom:area_square_m":2914770730.987321,
     "geom:bbox":"43.221846,17.366667,43.820587,18.351377",
     "geom:latitude":17.869335,
     "geom:longitude":43.516527,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SA.AS.ZJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SA",
     "wof:created":1476123479,
-    "wof:geomhash":"e899ab079ed5123641d95ad9370cc2aa",
+    "wof:geomhash":"8a7b2b21e23dea95bbbe47c12e8b1fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108720797,
-    "wof:lastmodified":1627522752,
+    "wof:lastmodified":1695886463,
     "wof:name":"Zahran al-Janub",
     "wof:parent_id":85676851,
     "wof:placetype":"county",

--- a/data/856/322/53/85632253.geojson
+++ b/data/856/322/53/85632253.geojson
@@ -1329,6 +1329,7 @@
         "hasc:id":"SA",
         "icao:code":"HZ",
         "ioc:id":"KSA",
+        "iso:code":"SA",
         "itu:id":"ARS",
         "loc:id":"n80131611",
         "m49:code":"682",
@@ -1343,6 +1344,7 @@
         "wk:page":"Saudi Arabia",
         "wmo:id":"SD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:country_alpha3":"SAU",
     "wof:geom_alt":[
@@ -1365,7 +1367,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639518,
+    "wof:lastmodified":1695881173,
     "wof:name":"Saudi Arabia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/768/09/85676809.geojson
+++ b/data/856/768/09/85676809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.869865,
-    "geom:area_square_m":127492021730.801544,
+    "geom:area_square_m":127492021730.800781,
     "geom:bbox":"43.596377,16.95,52.002109,19.450422",
     "geom:latitude":18.450584,
     "geom:longitude":46.867644,
@@ -333,16 +333,18 @@
         "gn:id":103628,
         "gp:id":2346960,
         "hasc:id":"SA.NJ",
+        "iso:code":"SA-10",
         "iso:id":"SA-10",
         "qs_pg:id":674493,
         "unlc:id":"SA-10",
         "wd:id":"Q464718"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"04c359246b88615529f6acb8f7aad40d",
+    "wof:geomhash":"e44a6a689c4654c23c0528e6b5964dac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860269,
+    "wof:lastmodified":1695884843,
     "wof:name":"Najran",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/13/85676813.geojson
+++ b/data/856/768/13/85676813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":33.11639,
-    "geom:area_square_m":376480966584.105103,
+    "geom:area_square_m":376480966584.101135,
     "geom:bbox":"41.681567,19.211674,48.237069,27.700039",
     "geom:latitude":23.08134,
     "geom:longitude":45.586126,
@@ -336,16 +336,18 @@
         "gn:id":108411,
         "gp:id":2346951,
         "hasc:id":"SA.RI",
+        "iso:code":"SA-01",
         "iso:id":"SA-01",
         "qs_pg:id":1135302,
         "unlc:id":"SA-01",
         "wd:id":"Q1249255"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b5c73d3ab76b8a83f0ad950dd7cbe24",
+    "wof:geomhash":"ead6d25d5d50bb280bf4e398a4de9c1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -360,7 +362,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860271,
+    "wof:lastmodified":1695885138,
     "wof:name":"Riyadh",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/19/85676819.geojson
+++ b/data/856/768/19/85676819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":46.261158,
-    "geom:area_square_m":524880806848.871094,
+    "geom:area_square_m":524880806848.876404,
     "geom:bbox":"44.366465,19.000336,55.6667,29.130772",
     "geom:latitude":23.27921,
     "geom:longitude":50.149936,
@@ -369,17 +369,19 @@
         "gn:id":108241,
         "gp:id":2346954,
         "hasc:id":"SA.SH",
+        "iso:code":"SA-04",
         "iso:id":"SA-04",
         "qs_pg:id":1135307,
         "unlc:id":"SA-04",
         "wd:id":"Q953508"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"213e493e46e88b140b9f75891bde876f",
+    "wof:geomhash":"ec57ed5ae4aefb5197b023cd3103984a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -394,7 +396,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860268,
+    "wof:lastmodified":1695884598,
     "wof:name":"Eastern Province",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/25/85676825.geojson
+++ b/data/856/768/25/85676825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.456142,
-    "geom:area_square_m":150853675884.933411,
+    "geom:area_square_m":150853675884.938812,
     "geom:bbox":"36.636475,22.523459,42.157219,27.490252",
     "geom:latitude":24.930073,
     "geom:longitude":39.490134,
@@ -361,16 +361,18 @@
         "gn:id":109224,
         "gp:id":2346958,
         "hasc:id":"SA.MD",
+        "iso:code":"SA-03",
         "iso:id":"SA-03",
         "qs_pg:id":1135311,
         "wd:id":"Q236027"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"bf37eba43130e05666f69af7c0b08cac",
+    "wof:geomhash":"4fde6d401dd728fa8e036c482d61ea97",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -385,7 +387,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860272,
+    "wof:lastmodified":1695884463,
     "wof:name":"Al Madinah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/27/85676827.geojson
+++ b/data/856/768/27/85676827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.360371,
-    "geom:area_square_m":70561240256.843811,
+    "geom:area_square_m":70561240256.844467,
     "geom:bbox":"41.300329,24.47996,44.984261,28.252979",
     "geom:latitude":26.196343,
     "geom:longitude":43.342925,
@@ -359,15 +359,17 @@
         "gn:id":108933,
         "gp:id":2346952,
         "hasc:id":"SA.QS",
+        "iso:code":"SA-05",
         "iso:id":"SA-05",
         "qs_pg:id":1135306,
         "wd:id":"Q1105411"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f822d2fe5d444b3868cf8ca1f2d67aba",
+    "wof:geomhash":"91378f4c383dc4ce88fc79dd37979210",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -382,7 +384,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860268,
+    "wof:lastmodified":1695884463,
     "wof:name":"Al-Qassim",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/31/85676831.geojson
+++ b/data/856/768/31/85676831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.673133,
-    "geom:area_square_m":117154777560.093384,
+    "geom:area_square_m":117154777560.093552,
     "geom:bbox":"39.117649,25.258007,44.367071,28.926008",
     "geom:latitude":27.400807,
     "geom:longitude":41.440619,
@@ -411,16 +411,18 @@
         "gn:id":106280,
         "gp:id":2346957,
         "hasc:id":"SA.HA",
+        "iso:code":"SA-06",
         "iso:id":"SA-06",
         "qs_pg:id":1135310,
         "unlc:id":"SA-06",
         "wd:id":"Q243656"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"831ee7d53a6dc9ce799674b73580b9a2",
+    "wof:geomhash":"9e744cddaea652def6dda57c16799055",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -435,7 +437,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860270,
+    "wof:lastmodified":1695884843,
     "wof:name":"Ha'il",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/33/85676833.geojson
+++ b/data/856/768/33/85676833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.059417,
-    "geom:area_square_m":131757068592.78006,
+    "geom:area_square_m":131757068592.785355,
     "geom:bbox":"34.572918,24.56654,40.060505,29.991911",
     "geom:latitude":27.901717,
     "geom:longitude":37.257916,
@@ -362,16 +362,18 @@
         "gn:id":101627,
         "gp:id":2346962,
         "hasc:id":"SA.TB",
+        "iso:code":"SA-07",
         "iso:id":"SA-07",
         "qs_pg:id":221726,
         "unlc:id":"SA-07",
         "wd:id":"Q1315953"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1b03b7ca30d2a2df12265368231a5a8",
+    "wof:geomhash":"39a1bdd80ee9611d1b68994116128387",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -386,7 +388,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860267,
+    "wof:lastmodified":1695884842,
     "wof:name":"Tabuk",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/37/85676837.geojson
+++ b/data/856/768/37/85676837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.50669,
-    "geom:area_square_m":101576534021.219315,
+    "geom:area_square_m":101576534021.21936,
     "geom:bbox":"37.913392,28.255783,45.731338,32.154284",
     "geom:latitude":30.202684,
     "geom:longitude":41.862127,
@@ -301,15 +301,17 @@
         "gn:id":109579,
         "gp:id":2346961,
         "hasc:id":"SA.HS",
+        "iso:code":"SA-08",
         "iso:id":"SA-08",
         "qs_pg:id":1135303,
         "wd:id":"Q201781"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c702851f8e0ede403434245cf98d0d7",
+    "wof:geomhash":"ff15f1a9887c7d400f40a5490215d330",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -324,7 +326,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860271,
+    "wof:lastmodified":1695884463,
     "wof:name":"Northern Borders",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/43/85676843.geojson
+++ b/data/856/768/43/85676843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.158655,
-    "geom:area_square_m":87385803284.18071,
+    "geom:area_square_m":87385803284.178497,
     "geom:bbox":"37.000897,28.370765,41.993367,31.749722",
     "geom:latitude":29.971993,
     "geom:longitude":39.553051,
@@ -347,15 +347,17 @@
         "gn:id":109470,
         "gp:id":2346950,
         "hasc:id":"SA.JF",
+        "iso:code":"SA-12",
         "iso:id":"SA-12",
         "qs_pg:id":1135305,
         "wd:id":"Q1471266"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6d09fbd189fb0c4d03863176c1e03297",
+    "wof:geomhash":"d7faa6c8f4167e1eb11f886ad034950a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -370,7 +372,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860269,
+    "wof:lastmodified":1695884843,
     "wof:name":"Al Jawf",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/47/85676847.geojson
+++ b/data/856/768/47/85676847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.956348,
-    "geom:area_square_m":11101672266.050604,
+    "geom:area_square_m":11101672266.050373,
     "geom:bbox":"40.837534,19.446056,42.128673,20.830865",
     "geom:latitude":20.147198,
     "geom:longitude":41.467053,
@@ -335,15 +335,17 @@
         "gn:id":109954,
         "gp:id":2346949,
         "hasc:id":"SA.BA",
+        "iso:code":"SA-11",
         "iso:id":"SA-11",
         "qs_pg:id":1135304,
         "wd:id":"Q852774"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1de76a4a8d80a30db853bf77f7979566",
+    "wof:geomhash":"44fa1e747a99e00bba202a6764dbb7a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -358,7 +360,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860271,
+    "wof:lastmodified":1695884464,
     "wof:name":"Al-Bahah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/51/85676851.geojson
+++ b/data/856/768/51/85676851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.614145,
-    "geom:area_square_m":77258086948.052704,
+    "geom:area_square_m":77258086948.054169,
     "geom:bbox":"41.363093,17.366667,44.484583,20.802293",
     "geom:latitude":19.137122,
     "geom:longitude":42.942466,
@@ -374,16 +374,18 @@
         "gn:id":108179,
         "gp:id":2346955,
         "hasc:id":"SA.AS",
+        "iso:code":"SA-14",
         "iso:id":"SA-14",
         "qs_pg:id":1135308,
         "unlc:id":"SA-14",
         "wd:id":"Q779855"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee13150c217ba49e8b24e3195256b6de",
+    "wof:geomhash":"e4baece555afe5a28f13d0f9a994ae1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -398,7 +400,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860267,
+    "wof:lastmodified":1695884464,
     "wof:name":"Aseer",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/53/85676853.geojson
+++ b/data/856/768/53/85676853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.099311,
-    "geom:area_square_m":12982773153.293596,
+    "geom:area_square_m":12982773153.294334,
     "geom:bbox":"41.564556,16.379528,43.3365,18.049528",
     "geom:latitude":17.231539,
     "geom:longitude":42.684461,
@@ -318,16 +318,18 @@
         "gn:id":105298,
         "gp:id":2346956,
         "hasc:id":"SA.JZ",
+        "iso:code":"SA-09",
         "iso:id":"SA-09",
         "qs_pg:id":1135309,
         "unlc:id":"SA-09",
         "wd:id":"Q269973"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f152c147b8304c4e5bea0c6b0d05421",
+    "wof:geomhash":"2695b90ac37a6e969afc10450e22ee01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860270,
+    "wof:lastmodified":1695884843,
     "wof:name":"Jizan",
     "wof:parent_id":85632253,
     "wof:placetype":"region",

--- a/data/856/768/57/85676857.geojson
+++ b/data/856/768/57/85676857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.253267,
-    "geom:area_square_m":140825102929.997803,
+    "geom:area_square_m":140825102929.98996,
     "geom:bbox":"38.643749,18.461195,43.829112,23.694888",
     "geom:latitude":21.628768,
     "geom:longitude":41.257286,
@@ -401,16 +401,18 @@
         "gn:id":104514,
         "gp:id":2346959,
         "hasc:id":"SA.MK",
+        "iso:code":"SA-02",
         "iso:id":"SA-02",
         "qs_pg:id":221725,
         "wd:id":"Q234167"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SA",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"6b3e661248a0e2a4350c0ce4794e1f29",
+    "wof:geomhash":"271afd67001f3b77601457b466c328db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -425,7 +427,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690860266,
+    "wof:lastmodified":1695884464,
     "wof:name":"Makkah",
     "wof:parent_id":85632253,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.